### PR TITLE
Expand core-engine unit test coverage (Tiers 1–4)

### DIFF
--- a/transitclock/pom.xml
+++ b/transitclock/pom.xml
@@ -259,7 +259,30 @@
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<version>4.11</version>
+			<version>4.13.2</version>
+			<scope>test</scope>
+		</dependency>
+		<!-- Mockito 5.x uses the inline mock-maker by default, so
+		     mockStatic / final-class mocking work with just mockito-core.
+		     Hibernate 5.5 pulls in byte-buddy 1.11 at compile scope, which
+		     wins classpath order over Mockito's newer byte-buddy and fails
+		     at runtime ("NoClassDefFoundError: GraalImageCode"). Pin to a
+		     newer byte-buddy explicitly; Hibernate is backward-compatible. -->
+		<dependency>
+			<groupId>net.bytebuddy</groupId>
+			<artifactId>byte-buddy</artifactId>
+			<version>1.14.15</version>
+		</dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+			<version>5.12.0</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.assertj</groupId>
+			<artifactId>assertj-core</artifactId>
+			<version>3.26.3</version>
 			<scope>test</scope>
 		</dependency>
 		<!-- Used for reflection to find classes in package -->

--- a/transitclock/src/test/java/org/transitclock/TestLibrariesSmokeTest.java
+++ b/transitclock/src/test/java/org/transitclock/TestLibrariesSmokeTest.java
@@ -1,0 +1,69 @@
+package org.transitclock;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.transitclock.utils.MathUtils;
+import org.transitclock.utils.SystemTime;
+
+/**
+ * Verifies that JUnit 4.13.2 (assertThrows), Mockito 5 core + inline
+ * (mockStatic), and AssertJ 3 are all wired up correctly on the test
+ * classpath. If any of these break at build time, there's no point
+ * writing Tier 1 tests on top of them.
+ */
+public class TestLibrariesSmokeTest {
+
+	@Test
+	public void junit_413_assertThrowsIsAvailable() {
+		IllegalArgumentException ex = assertThrows(
+				IllegalArgumentException.class,
+				() -> { throw new IllegalArgumentException("boom"); });
+		assertThat(ex).hasMessage("boom");
+	}
+
+	@Test
+	public void mockito_canStubAndVerifyInstanceMethods() {
+		SystemTime time = mock(SystemTime.class);
+		when(time.get()).thenReturn(1_700_000_000_000L);
+
+		long first = time.get();
+		long second = time.get();
+
+		assertThat(first).isEqualTo(1_700_000_000_000L);
+		assertThat(second).isEqualTo(1_700_000_000_000L);
+		verify(time, times(2)).get();
+	}
+
+	@Test
+	public void mockitoInline_canMockStaticMethods() {
+		try (MockedStatic<MathUtils> mocked = mockStatic(MathUtils.class)) {
+			mocked.when(() -> MathUtils.round(1.2345, 2)).thenReturn(9.99);
+
+			assertThat(MathUtils.round(1.2345, 2)).isEqualTo(9.99);
+			mocked.verify(() -> MathUtils.round(1.2345, 2));
+		}
+
+		// Outside the scope, the real implementation is restored.
+		assertThat(MathUtils.round(1.2345, 2)).isCloseTo(1.23, within(1e-9));
+	}
+
+	@Test
+	public void assertj_fluentChainedAssertions() {
+		assertThat("TheTransitClock")
+				.isNotNull()
+				.startsWith("The")
+				.endsWith("Clock")
+				.hasSize(15);
+
+		assertThat(3.14159).isCloseTo(Math.PI, within(0.001));
+	}
+}

--- a/transitclock/src/test/java/org/transitclock/core/ArrivalDepartureGeneratorDefaultImplTest.java
+++ b/transitclock/src/test/java/org/transitclock/core/ArrivalDepartureGeneratorDefaultImplTest.java
@@ -2,6 +2,8 @@ package org.transitclock.core;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
@@ -22,11 +24,8 @@ public class ArrivalDepartureGeneratorDefaultImplTest {
 
 		new ArrivalDepartureGeneratorDefaultImpl().generate(vs);
 
-		// The method returns early; nothing else on the mock should have been
-		// touched. isPredictable() will show in interactions, so we just
-		// re-assert the guard held by checking getMatch() was never consulted.
-		// Using a looser check here since Mockito's strict mode isn't enabled.
-		assertThat(vs.isPredictable()).isFalse();
+		verify(vs).isPredictable();
+		verify(vs, never()).getMatch();
 	}
 
 	@Test
@@ -35,20 +34,25 @@ public class ArrivalDepartureGeneratorDefaultImplTest {
 		when(vs.isPredictable()).thenReturn(true);
 		when(vs.getMatch()).thenReturn(null);
 
-		// Should not throw, should not reach any downstream processing.
 		new ArrivalDepartureGeneratorDefaultImpl().generate(vs);
+
+		verify(vs).isPredictable();
+		verify(vs).getMatch();
+		verify(vs, never()).getPreviousMatch();
 	}
 
 	@Test
 	public void generate_doesNotTouchTrivialCollaboratorsWhenUnpredictable() {
 		VehicleState vs = mock(VehicleState.class);
 		when(vs.isPredictable()).thenReturn(false);
-		SpatialMatch match = mock(SpatialMatch.class);
+		TemporalMatch match = mock(TemporalMatch.class);
+		when(vs.getMatch()).thenReturn(match);
 
 		new ArrivalDepartureGeneratorDefaultImpl().generate(vs);
 
-		// Since the method short-circuits, it should never have asked for a
-		// match or a previous match.
+		verify(vs).isPredictable();
+		// Guard short-circuited before ever reading match off the state.
+		verify(vs, never()).getMatch();
 		verifyNoInteractions(match);
 	}
 }

--- a/transitclock/src/test/java/org/transitclock/core/ArrivalDepartureGeneratorDefaultImplTest.java
+++ b/transitclock/src/test/java/org/transitclock/core/ArrivalDepartureGeneratorDefaultImplTest.java
@@ -1,0 +1,54 @@
+package org.transitclock.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import org.junit.Test;
+
+public class ArrivalDepartureGeneratorDefaultImplTest {
+
+	@Test
+	public void implementsArrivalDepartureGenerator() {
+		assertThat(new ArrivalDepartureGeneratorDefaultImpl())
+				.isInstanceOf(ArrivalDepartureGenerator.class);
+	}
+
+	@Test
+	public void generate_unpredictableVehicleIsANoOp() {
+		VehicleState vs = mock(VehicleState.class);
+		when(vs.isPredictable()).thenReturn(false);
+
+		new ArrivalDepartureGeneratorDefaultImpl().generate(vs);
+
+		// The method returns early; nothing else on the mock should have been
+		// touched. isPredictable() will show in interactions, so we just
+		// re-assert the guard held by checking getMatch() was never consulted.
+		// Using a looser check here since Mockito's strict mode isn't enabled.
+		assertThat(vs.isPredictable()).isFalse();
+	}
+
+	@Test
+	public void generate_nullMatchIsANoOp() {
+		VehicleState vs = mock(VehicleState.class);
+		when(vs.isPredictable()).thenReturn(true);
+		when(vs.getMatch()).thenReturn(null);
+
+		// Should not throw, should not reach any downstream processing.
+		new ArrivalDepartureGeneratorDefaultImpl().generate(vs);
+	}
+
+	@Test
+	public void generate_doesNotTouchTrivialCollaboratorsWhenUnpredictable() {
+		VehicleState vs = mock(VehicleState.class);
+		when(vs.isPredictable()).thenReturn(false);
+		SpatialMatch match = mock(SpatialMatch.class);
+
+		new ArrivalDepartureGeneratorDefaultImpl().generate(vs);
+
+		// Since the method short-circuits, it should never have asked for a
+		// match or a previous match.
+		verifyNoInteractions(match);
+	}
+}

--- a/transitclock/src/test/java/org/transitclock/core/AvlProcessorTest.java
+++ b/transitclock/src/test/java/org/transitclock/core/AvlProcessorTest.java
@@ -1,0 +1,29 @@
+package org.transitclock.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+public class AvlProcessorTest {
+
+	@Test
+	public void getInstance_returnsSingleton() {
+		assertThat(AvlProcessor.getInstance())
+				.isNotNull()
+				.isSameAs(AvlProcessor.getInstance());
+	}
+
+	@Test
+	public void lastAvlReportTime_isZeroBeforeAnyReportIsProcessed() {
+		// The singleton may have been touched by other tests that preceded this
+		// one, so we don't assume a "clean" state — we only assert the
+		// contract: if no regular report has been stored yet, the method
+		// returns 0, otherwise it returns the epoch time of the stored report.
+		AvlProcessor p = AvlProcessor.getInstance();
+		if (p.getLastAvlReport() == null) {
+			assertThat(p.lastAvlReportTime()).isEqualTo(0L);
+		} else {
+			assertThat(p.lastAvlReportTime()).isEqualTo(p.getLastAvlReport().getTime());
+		}
+	}
+}

--- a/transitclock/src/test/java/org/transitclock/core/BlockAssignerTest.java
+++ b/transitclock/src/test/java/org/transitclock/core/BlockAssignerTest.java
@@ -1,0 +1,247 @@
+package org.transitclock.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+
+import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.transitclock.applications.Core;
+import org.transitclock.db.structs.AvlReport;
+import org.transitclock.db.structs.Block;
+import org.transitclock.db.structs.Trip;
+import org.transitclock.gtfs.DbConfig;
+
+public class BlockAssignerTest {
+
+	@Test
+	public void getInstance_returnsSingleton() {
+		assertThat(BlockAssigner.getInstance())
+				.isNotNull()
+				.isSameAs(BlockAssigner.getInstance());
+	}
+
+	@Test
+	public void getBlockAssignment_nullReportReturnsNull() {
+		assertThat(BlockAssigner.getInstance().getBlockAssignment(null)).isNull();
+	}
+
+	@Test
+	public void getBlockAssignment_nullAssignmentIdReturnsNull() {
+		AvlReport report = mock(AvlReport.class);
+		when(report.getAssignmentId()).thenReturn(null);
+
+		assertThat(BlockAssigner.getInstance().getBlockAssignment(report)).isNull();
+	}
+
+	@Test
+	public void getBlockAssignment_routeTypeReturnsNull() {
+		AvlReport report = mock(AvlReport.class);
+		when(report.getAssignmentId()).thenReturn("route-1");
+		when(report.isBlockIdAssignmentType()).thenReturn(false);
+		when(report.isTripIdAssignmentType()).thenReturn(false);
+		when(report.isTripShortNameAssignmentType()).thenReturn(false);
+		when(report.isRouteIdAssignmentType()).thenReturn(true);
+
+		try (MockedStatic<Core> coreMock = mockStatic(Core.class)) {
+			Core core = mock(Core.class);
+			when(core.getDbConfig()).thenReturn(mock(DbConfig.class));
+			coreMock.when(Core::getInstance).thenReturn(core);
+
+			assertThat(BlockAssigner.getInstance().getBlockAssignment(report)).isNull();
+		}
+	}
+
+	@Test
+	public void getBlockAssignment_blockTypeFindsActiveBlockForServiceId() {
+		AvlReport report = mock(AvlReport.class);
+		when(report.getAssignmentId()).thenReturn("block-42");
+		when(report.getVehicleId()).thenReturn("veh-1");
+		when(report.isBlockIdAssignmentType()).thenReturn(true);
+		when(report.getDate()).thenReturn(new Date(1_700_000_000_000L));
+		when(report.getTime()).thenReturn(1_700_000_000_000L);
+
+		Block block = mock(Block.class);
+		when(block.getId()).thenReturn("block-42");
+		when(block.isActive(1_700_000_000_000L, 90 * 60)).thenReturn(true);
+
+		DbConfig dbConfig = mock(DbConfig.class);
+		when(dbConfig.getBlock("weekday", "block-42")).thenReturn(block);
+
+		ServiceUtils serviceUtils = mock(ServiceUtils.class);
+		when(serviceUtils.getServiceIds(report.getDate()))
+				.thenReturn(Collections.singletonList("weekday"));
+
+		try (MockedStatic<Core> coreMock = mockStatic(Core.class)) {
+			Core core = mock(Core.class);
+			when(core.getDbConfig()).thenReturn(dbConfig);
+			when(core.getServiceUtils()).thenReturn(serviceUtils);
+			coreMock.when(Core::getInstance).thenReturn(core);
+
+			Block result = BlockAssigner.getInstance().getBlockAssignment(report);
+
+			assertThat(result).isSameAs(block);
+		}
+	}
+
+	@Test
+	public void getBlockAssignment_blockTypeNoMatchReturnsNull() {
+		AvlReport report = mock(AvlReport.class);
+		when(report.getAssignmentId()).thenReturn("block-unknown");
+		when(report.getVehicleId()).thenReturn("veh-1");
+		when(report.isBlockIdAssignmentType()).thenReturn(true);
+		when(report.getDate()).thenReturn(new Date(1_700_000_000_000L));
+
+		DbConfig dbConfig = mock(DbConfig.class);
+		when(dbConfig.getBlock("weekday", "block-unknown")).thenReturn(null);
+
+		ServiceUtils serviceUtils = mock(ServiceUtils.class);
+		when(serviceUtils.getServiceIds(report.getDate()))
+				.thenReturn(Collections.singletonList("weekday"));
+
+		try (MockedStatic<Core> coreMock = mockStatic(Core.class)) {
+			Core core = mock(Core.class);
+			when(core.getDbConfig()).thenReturn(dbConfig);
+			when(core.getServiceUtils()).thenReturn(serviceUtils);
+			coreMock.when(Core::getInstance).thenReturn(core);
+
+			assertThat(BlockAssigner.getInstance().getBlockAssignment(report)).isNull();
+		}
+	}
+
+	@Test
+	public void getBlockAssignment_blockTypeChoosesActiveOverInactiveForMultipleServiceIds() {
+		AvlReport report = mock(AvlReport.class);
+		when(report.getAssignmentId()).thenReturn("block-42");
+		when(report.getVehicleId()).thenReturn("veh-1");
+		when(report.isBlockIdAssignmentType()).thenReturn(true);
+		when(report.getDate()).thenReturn(new Date(1_700_000_000_000L));
+		when(report.getTime()).thenReturn(1_700_000_000_000L);
+
+		Block yesterdayBlock = mock(Block.class);
+		when(yesterdayBlock.getId()).thenReturn("block-42");
+		when(yesterdayBlock.isActive(1_700_000_000_000L, 90 * 60)).thenReturn(false);
+
+		Block todayBlock = mock(Block.class);
+		when(todayBlock.getId()).thenReturn("block-42");
+		when(todayBlock.isActive(1_700_000_000_000L, 90 * 60)).thenReturn(true);
+
+		DbConfig dbConfig = mock(DbConfig.class);
+		when(dbConfig.getBlock("yesterday", "block-42")).thenReturn(yesterdayBlock);
+		when(dbConfig.getBlock("today", "block-42")).thenReturn(todayBlock);
+
+		ServiceUtils serviceUtils = mock(ServiceUtils.class);
+		// "yesterday" first so the initial activeBlock is the inactive one;
+		// then "today" arrives and isActive replaces it.
+		when(serviceUtils.getServiceIds(report.getDate()))
+				.thenReturn(Arrays.asList("yesterday", "today"));
+
+		try (MockedStatic<Core> coreMock = mockStatic(Core.class)) {
+			Core core = mock(Core.class);
+			when(core.getDbConfig()).thenReturn(dbConfig);
+			when(core.getServiceUtils()).thenReturn(serviceUtils);
+			coreMock.when(Core::getInstance).thenReturn(core);
+
+			Block result = BlockAssigner.getInstance().getBlockAssignment(report);
+
+			assertThat(result).isSameAs(todayBlock);
+		}
+	}
+
+	@Test
+	public void getBlockAssignment_tripIdTypeReturnsTripsBlock() {
+		AvlReport report = mock(AvlReport.class);
+		when(report.getAssignmentId()).thenReturn("trip-1");
+		when(report.getVehicleId()).thenReturn("veh-1");
+		when(report.isBlockIdAssignmentType()).thenReturn(false);
+		when(report.isTripIdAssignmentType()).thenReturn(true);
+
+		Block block = mock(Block.class);
+		when(block.getId()).thenReturn("block-99");
+
+		Trip trip = mock(Trip.class);
+		when(trip.getBlock()).thenReturn(block);
+
+		DbConfig dbConfig = mock(DbConfig.class);
+		when(dbConfig.getTrip("trip-1")).thenReturn(trip);
+
+		try (MockedStatic<Core> coreMock = mockStatic(Core.class)) {
+			Core core = mock(Core.class);
+			when(core.getDbConfig()).thenReturn(dbConfig);
+			coreMock.when(Core::getInstance).thenReturn(core);
+
+			assertThat(BlockAssigner.getInstance().getBlockAssignment(report)).isSameAs(block);
+		}
+	}
+
+	@Test
+	public void getBlockAssignment_tripIdTypeUnknownTripReturnsNull() {
+		AvlReport report = mock(AvlReport.class);
+		when(report.getAssignmentId()).thenReturn("trip-unknown");
+		when(report.getVehicleId()).thenReturn("veh-1");
+		when(report.isTripIdAssignmentType()).thenReturn(true);
+
+		DbConfig dbConfig = mock(DbConfig.class);
+		when(dbConfig.getTrip("trip-unknown")).thenReturn(null);
+
+		try (MockedStatic<Core> coreMock = mockStatic(Core.class)) {
+			Core core = mock(Core.class);
+			when(core.getDbConfig()).thenReturn(dbConfig);
+			coreMock.when(Core::getInstance).thenReturn(core);
+
+			assertThat(BlockAssigner.getInstance().getBlockAssignment(report)).isNull();
+		}
+	}
+
+	@Test
+	public void getBlockAssignment_tripShortNameTypeReturnsTripsBlock() {
+		AvlReport report = mock(AvlReport.class);
+		when(report.getAssignmentId()).thenReturn("short-A");
+		when(report.getVehicleId()).thenReturn("veh-1");
+		when(report.isTripShortNameAssignmentType()).thenReturn(true);
+
+		Block block = mock(Block.class);
+		when(block.getId()).thenReturn("block-7");
+		Trip trip = mock(Trip.class);
+		when(trip.getBlock()).thenReturn(block);
+
+		DbConfig dbConfig = mock(DbConfig.class);
+		when(dbConfig.getTripUsingTripShortName("short-A")).thenReturn(trip);
+
+		try (MockedStatic<Core> coreMock = mockStatic(Core.class)) {
+			Core core = mock(Core.class);
+			when(core.getDbConfig()).thenReturn(dbConfig);
+			coreMock.when(Core::getInstance).thenReturn(core);
+
+			assertThat(BlockAssigner.getInstance().getBlockAssignment(report)).isSameAs(block);
+		}
+	}
+
+	@Test
+	public void getRouteIdAssignment_returnsAssignmentWhenRouteType() {
+		AvlReport report = mock(AvlReport.class);
+		when(report.getAssignmentId()).thenReturn("route-9");
+		when(report.isRouteIdAssignmentType()).thenReturn(true);
+
+		assertThat(BlockAssigner.getInstance().getRouteIdAssignment(report)).isEqualTo("route-9");
+	}
+
+	@Test
+	public void getRouteIdAssignment_returnsNullWhenNotRouteType() {
+		AvlReport report = mock(AvlReport.class);
+		when(report.getAssignmentId()).thenReturn("block-5");
+		when(report.isRouteIdAssignmentType()).thenReturn(false);
+
+		assertThat(BlockAssigner.getInstance().getRouteIdAssignment(report)).isNull();
+	}
+
+	@Test
+	public void getRouteIdAssignment_returnsNullForNullReport() {
+		assertThat(BlockAssigner.getInstance().getRouteIdAssignment(null)).isNull();
+	}
+}

--- a/transitclock/src/test/java/org/transitclock/core/CoreVehicleStateTest.java
+++ b/transitclock/src/test/java/org/transitclock/core/CoreVehicleStateTest.java
@@ -1,0 +1,143 @@
+package org.transitclock.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Date;
+
+import org.junit.Test;
+import org.transitclock.db.structs.AvlReport;
+import org.transitclock.db.structs.Headway;
+import org.transitclock.db.structs.HoldingTime;
+
+/**
+ * Named {@code CoreVehicleStateTest} to keep it distinct from the existing
+ * VehicleStateTest that lives in {@code db/structs/} and tests a different
+ * (entity) class of the same name.
+ */
+public class CoreVehicleStateTest {
+
+	@Test
+	public void newVehicleState_hasVehicleIdAndSensibleDefaults() {
+		VehicleState vs = new VehicleState("veh-42");
+
+		assertThat(vs.getVehicleId()).isEqualTo("veh-42");
+		assertThat(vs.isPredictable()).isFalse();
+		assertThat(vs.getMatch()).isNull();
+		assertThat(vs.getAvlReport()).isNull();
+		assertThat(vs.getHeadway()).isNull();
+		assertThat(vs.getHoldingTime()).isNull();
+		assertThat(vs.numberOfBadMatches()).isEqualTo(0);
+		assertThat(vs.overLimitOfBadMatches()).isFalse();
+	}
+
+	@Test
+	public void setAvlReport_pushesOntoHistoryAndIsReturnedAsCurrent() {
+		VehicleState vs = new VehicleState("veh-1");
+		AvlReport first = avlReportAt(1_000L);
+		AvlReport second = avlReportAt(2_000L);
+
+		vs.setAvlReport(first);
+		assertThat(vs.getAvlReport()).isSameAs(first);
+
+		vs.setAvlReport(second);
+		assertThat(vs.getAvlReport()).isSameAs(second);
+	}
+
+	@Test
+	public void incrementNumberOfBadMatches_walksTowardLimit() {
+		VehicleState vs = new VehicleState("veh-1");
+
+		vs.incrementNumberOfBadMatches();
+		vs.incrementNumberOfBadMatches();
+
+		assertThat(vs.numberOfBadMatches()).isEqualTo(2);
+	}
+
+	@Test
+	public void setMatch_nullMakesVehicleUnpredictableAndResetsBadMatches() {
+		VehicleState vs = new VehicleState("veh-1");
+		vs.incrementNumberOfBadMatches();
+
+		vs.setMatch(null);
+
+		assertThat(vs.isPredictable()).isFalse();
+		assertThat(vs.numberOfBadMatches()).isEqualTo(0);
+		assertThat(vs.getMatch()).isNull();
+	}
+
+	@Test
+	public void setMatch_nonNullIsRetrievable() {
+		VehicleState vs = new VehicleState("veh-1");
+		TemporalMatch m = mock(TemporalMatch.class);
+
+		vs.setMatch(m);
+
+		assertThat(vs.getMatch()).isSameAs(m);
+	}
+
+	@Test
+	public void setHeadway_andHoldingTimeRoundtrip() {
+		VehicleState vs = new VehicleState("veh-1");
+		Headway h = mock(Headway.class);
+		HoldingTime ht = mock(HoldingTime.class);
+
+		vs.setHeadway(h);
+		vs.setHoldingTime(ht);
+
+		assertThat(vs.getHeadway()).isSameAs(h);
+		assertThat(vs.getHoldingTime()).isSameAs(ht);
+	}
+
+	@Test
+	public void incrementTripCounter_startsAtZeroAndIncrements() {
+		VehicleState vs = new VehicleState("veh-1");
+		assertThat(vs.getTripCounter()).isEqualTo(0);
+
+		vs.incrementTripCounter();
+		assertThat(vs.getTripCounter()).isEqualTo(1);
+
+		vs.incrementTripCounter();
+		assertThat(vs.getTripCounter()).isEqualTo(2);
+	}
+
+	@Test
+	public void putAndGetTripStartTime_roundtripsOnTripCounter() {
+		VehicleState vs = new VehicleState("veh-1");
+		vs.putTripStartTime(5, 123_456_789L);
+
+		assertThat(vs.getTripStartTime(5)).isEqualTo(123_456_789L);
+		assertThat(vs.getTripStartTime(999)).isNull();
+	}
+
+	@Test
+	public void arrivalToStoreToDb_setAndGet() {
+		VehicleState vs = new VehicleState("veh-1");
+		org.transitclock.db.structs.Arrival arrival =
+				mock(org.transitclock.db.structs.Arrival.class);
+
+		vs.setArrivalToStoreToDb(arrival);
+
+		assertThat(vs.getArrivalToStoreToDb()).isSameAs(arrival);
+	}
+
+	@Test
+	public void realTimeSchedAdh_isOnlyVisibleWhenPredictable() {
+		// Stored internally but getRealTimeSchedAdh() hides it from
+		// unpredictable vehicles. A fresh VehicleState is not predictable.
+		VehicleState vs = new VehicleState("veh-1");
+		TemporalDifference diff = new TemporalDifference(15_000);
+
+		vs.setRealTimeSchedAdh(diff);
+
+		assertThat(vs.getRealTimeSchedAdh()).isNull(); // not predictable → null
+	}
+
+	private static AvlReport avlReportAt(long epochMs) {
+		AvlReport report = mock(AvlReport.class);
+		when(report.getTime()).thenReturn(epochMs);
+		when(report.getDate()).thenReturn(new Date(epochMs));
+		return report;
+	}
+}

--- a/transitclock/src/test/java/org/transitclock/core/PredictionGeneratorDefaultImplTest.java
+++ b/transitclock/src/test/java/org/transitclock/core/PredictionGeneratorDefaultImplTest.java
@@ -1,0 +1,87 @@
+package org.transitclock.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.Test;
+import org.transitclock.db.structs.AvlReport;
+import org.transitclock.db.structs.TravelTimesForStopPath;
+import org.transitclock.db.structs.Trip;
+
+public class PredictionGeneratorDefaultImplTest {
+
+	@Test
+	public void getMaxPredictionsTimeSecs_defaultIs45Minutes() {
+		// Config default: 45 * 60 = 2700 seconds.
+		assertThat(PredictionGeneratorDefaultImpl.getMaxPredictionsTimeSecs())
+				.isEqualTo(45 * 60);
+	}
+
+	@Test
+	public void getTravelTimeForPath_returnsIndicesTravelTimeWhenStoreFlagOff() {
+		// The store-predictions config defaults to false, so the method should
+		// just return indices.getTravelTimeForPath() unchanged.
+		Indices indices = mock(Indices.class);
+		when(indices.getTravelTimeForPath()).thenReturn(12_345);
+
+		PredictionGeneratorDefaultImpl gen = new PredictionGeneratorDefaultImpl();
+
+		long result = gen.getTravelTimeForPath(indices, mock(AvlReport.class),
+				mock(VehicleState.class));
+
+		assertThat(result).isEqualTo(12_345L);
+	}
+
+	@Test
+	public void getStopTimeForPath_delegatesToTravelTimes() {
+		TravelTimesForStopPath ttsp = mock(TravelTimesForStopPath.class);
+		when(ttsp.getStopTimeMsec()).thenReturn(30_000);
+
+		Trip trip = mock(Trip.class);
+		when(trip.getTravelTimesForStopPath(2)).thenReturn(ttsp);
+
+		Indices indices = mock(Indices.class);
+		when(indices.getTrip()).thenReturn(trip);
+		when(indices.getStopPathIndex()).thenReturn(2);
+
+		PredictionGeneratorDefaultImpl gen = new PredictionGeneratorDefaultImpl();
+
+		long result = gen.getStopTimeForPath(indices, mock(AvlReport.class),
+				mock(VehicleState.class));
+
+		assertThat(result).isEqualTo(30_000L);
+	}
+
+	@Test
+	public void expectedTravelTimeFromMatchToEndOfStopPath_delegatesToTravelTimes() {
+		// This path hits a real SpatialMatch-backed TravelTimes call; the
+		// simplest way to get signal is to mock the trip + TravelTimesForStopPath
+		// the helper will look up.
+		TravelTimesForStopPath ttsp = mock(TravelTimesForStopPath.class);
+		when(ttsp.getNumberTravelTimeSegments()).thenReturn(1);
+		when(ttsp.getTravelTimeSegmentMsec(0)).thenReturn(10_000);
+		when(ttsp.getStopPathTravelTimeMsec()).thenReturn(10_000);
+
+		Trip trip = mock(Trip.class);
+		when(trip.getTravelTimesForStopPath(0)).thenReturn(ttsp);
+
+		org.transitclock.db.structs.StopPath stopPath =
+				mock(org.transitclock.db.structs.StopPath.class);
+		when(stopPath.getLength()).thenReturn(100.0);
+
+		SpatialMatch match = mock(SpatialMatch.class);
+		when(match.getTrip()).thenReturn(trip);
+		when(match.getStopPathIndex()).thenReturn(0);
+		when(match.getStopPath()).thenReturn(stopPath);
+		when(match.getDistanceAlongStopPath()).thenReturn(0.0); // at start of path
+
+		PredictionGeneratorDefaultImpl gen = new PredictionGeneratorDefaultImpl();
+
+		long result = gen.expectedTravelTimeFromMatchToEndOfStopPath(
+				mock(AvlReport.class), match);
+
+		// At start of path, the full 10_000 ms of travel time remains.
+		assertThat(result).isEqualTo(10_000L);
+	}
+}

--- a/transitclock/src/test/java/org/transitclock/core/RealTimeSchedAdhProcessorTest.java
+++ b/transitclock/src/test/java/org/transitclock/core/RealTimeSchedAdhProcessorTest.java
@@ -1,0 +1,140 @@
+package org.transitclock.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import java.util.Date;
+
+import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.transitclock.applications.Core;
+import org.transitclock.db.structs.AvlReport;
+import org.transitclock.db.structs.ScheduleTime;
+import org.transitclock.db.structs.Trip;
+import org.transitclock.utils.Time;
+
+public class RealTimeSchedAdhProcessorTest {
+
+	private static final long AVL_EPOCH = 1_700_000_000_000L;
+
+	@Test
+	public void generate_returnsNullWhenNotPredictable() {
+		VehicleState vs = mock(VehicleState.class);
+		when(vs.isPredictable()).thenReturn(false);
+
+		assertThat(RealTimeSchedAdhProcessor.generate(vs)).isNull();
+	}
+
+	@Test
+	public void generate_atWaitStopBeforeDepartureReturnsZero() {
+		long departureEpoch = AVL_EPOCH + 60_000L;
+		VehicleState vs = predictableState();
+		VehicleAtStopInfo stopInfo = waitStopWithDeparture(43200);
+		when(vs.getMatch().getAtStop()).thenReturn(stopInfo);
+
+		try (MockedStatic<Core> coreMock = stubCoreWithEpochTime(43200, departureEpoch)) {
+			TemporalDifference result = RealTimeSchedAdhProcessor.generate(vs);
+
+			assertThat(result).isNotNull();
+			assertThat(result.getTemporalDifference()).isEqualTo(0);
+		}
+	}
+
+	@Test
+	public void generate_atWaitStopAfterDepartureReturnsLateness() {
+		long departureEpoch = AVL_EPOCH - 30_000L;
+		VehicleState vs = predictableState();
+		VehicleAtStopInfo stopInfo = waitStopWithDeparture(43200);
+		when(vs.getMatch().getAtStop()).thenReturn(stopInfo);
+
+		try (MockedStatic<Core> coreMock = stubCoreWithEpochTime(43200, departureEpoch)) {
+			TemporalDifference result = RealTimeSchedAdhProcessor.generate(vs);
+
+			assertThat(result).isNotNull();
+			assertThat(result.getTemporalDifference())
+					.isEqualTo((int) (departureEpoch - AVL_EPOCH));
+		}
+	}
+
+	@Test
+	public void generate_atRegularStopWithDepartureReturnsDifference() {
+		long departureEpoch = AVL_EPOCH + 45_000L;
+		VehicleState vs = predictableState();
+		VehicleAtStopInfo stopInfo = mock(VehicleAtStopInfo.class);
+		ScheduleTime schedTime = new ScheduleTime(null, 43200);
+		when(stopInfo.getScheduleTime()).thenReturn(schedTime);
+		when(stopInfo.isWaitStop()).thenReturn(false);
+		when(vs.getMatch().getAtStop()).thenReturn(stopInfo);
+
+		try (MockedStatic<Core> coreMock = stubCoreWithEpochTime(43200, departureEpoch)) {
+			TemporalDifference result = RealTimeSchedAdhProcessor.generate(vs);
+
+			assertThat(result).isNotNull();
+			assertThat(result.getTemporalDifference())
+					.isEqualTo((int) (departureEpoch - AVL_EPOCH));
+		}
+	}
+
+	@Test
+	public void generate_notAtStopAndNoUpcomingScheduledStopReturnsNull() {
+		VehicleState vs = predictableState();
+		when(vs.getMatch().getAtStop()).thenReturn(null);
+		when(vs.getMatch().getMatchAtNextStopWithScheduleTime()).thenReturn(null);
+
+		assertThat(RealTimeSchedAdhProcessor.generate(vs)).isNull();
+	}
+
+	@Test
+	public void generate_atStopButScheduleTimeNullFallsThroughToUpcomingStop() {
+		// When a stopInfo exists but has no ScheduleTime, the method must
+		// fall through to the "look at next stop with schedule time" branch.
+		VehicleState vs = predictableState();
+		VehicleAtStopInfo stopInfo = mock(VehicleAtStopInfo.class);
+		when(stopInfo.getScheduleTime()).thenReturn(null);
+		when(vs.getMatch().getAtStop()).thenReturn(stopInfo);
+		when(vs.getMatch().getMatchAtNextStopWithScheduleTime()).thenReturn(null);
+
+		assertThat(RealTimeSchedAdhProcessor.generate(vs)).isNull();
+	}
+
+	private VehicleState predictableState() {
+		VehicleState vs = mock(VehicleState.class);
+		when(vs.isPredictable()).thenReturn(true);
+		when(vs.getVehicleId()).thenReturn("veh-1");
+
+		AvlReport avl = mock(AvlReport.class);
+		when(avl.getDate()).thenReturn(new Date(AVL_EPOCH));
+		when(vs.getAvlReport()).thenReturn(avl);
+
+		TemporalMatch match = mock(TemporalMatch.class);
+		Trip trip = mock(Trip.class);
+		when(match.getTrip()).thenReturn(trip);
+		when(vs.getMatch()).thenReturn(match);
+		return vs;
+	}
+
+	private static VehicleAtStopInfo waitStopWithDeparture(int scheduledDeparture) {
+		VehicleAtStopInfo stopInfo = mock(VehicleAtStopInfo.class);
+		when(stopInfo.getScheduleTime()).thenReturn(new ScheduleTime(null, scheduledDeparture));
+		when(stopInfo.isWaitStop()).thenReturn(true);
+		return stopInfo;
+	}
+
+	private static MockedStatic<Core> stubCoreWithEpochTime(int scheduledSecs,
+			long returnedEpoch) {
+		Time time = mock(Time.class);
+		when(time.getEpochTime(eq(scheduledSecs), any(Date.class))).thenReturn(returnedEpoch);
+
+		Core core = mock(Core.class);
+		when(core.getTime()).thenReturn(time);
+
+		MockedStatic<Core> coreMock = mockStatic(Core.class);
+		coreMock.when(Core::getInstance).thenReturn(core);
+		return coreMock;
+	}
+
+}

--- a/transitclock/src/test/java/org/transitclock/core/ServiceUtilsTest.java
+++ b/transitclock/src/test/java/org/transitclock/core/ServiceUtilsTest.java
@@ -1,0 +1,176 @@
+package org.transitclock.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.TimeZone;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.transitclock.db.structs.Agency;
+import org.transitclock.db.structs.Calendar;
+import org.transitclock.db.structs.CalendarDate;
+import org.transitclock.gtfs.DbConfig;
+
+public class ServiceUtilsTest {
+
+	// Noon UTC on known weekdays so TZ offsets don't flip the day.
+	private static final long MON_2024_06_03_NOON_UTC = 1_717_416_000_000L;
+	private static final long TUE_2024_06_04_NOON_UTC = 1_717_502_400_000L;
+
+	private DbConfig dbConfig;
+	private Agency agency;
+
+	@Before
+	public void setUp() {
+		dbConfig = mock(DbConfig.class);
+		agency = mock(Agency.class);
+		when(agency.getTimeZone()).thenReturn(TimeZone.getTimeZone("UTC"));
+		when(dbConfig.getFirstAgency()).thenReturn(agency);
+		when(dbConfig.getCalendars()).thenReturn(Collections.emptyList());
+		when(dbConfig.getCalendarDates(any(Date.class))).thenReturn(null);
+	}
+
+	@Test
+	public void getDayOfWeek_returnsAgencyLocalDayOfWeek() {
+		ServiceUtils utils = new ServiceUtils(dbConfig);
+
+		assertThat(utils.getDayOfWeek(new Date(MON_2024_06_03_NOON_UTC)))
+				.isEqualTo(java.util.Calendar.MONDAY);
+		assertThat(utils.getDayOfWeek(new Date(TUE_2024_06_04_NOON_UTC)))
+				.isEqualTo(java.util.Calendar.TUESDAY);
+	}
+
+	@Test
+	public void constructor_withNoAgencyStillWorks() {
+		when(dbConfig.getFirstAgency()).thenReturn(null);
+
+		ServiceUtils utils = new ServiceUtils(dbConfig);
+
+		// Fall-through is a default-timezone GregorianCalendar; still functional.
+		assertThat(utils.getDayOfWeek(new Date(MON_2024_06_03_NOON_UTC))).isPositive();
+	}
+
+	@Test
+	public void getServiceIdsForDayNoCache_returnsIdsMatchingDayOfWeek() {
+		Calendar weekday = calendarFor("weekday", true, true, true, true, true, false, false,
+				MON_2024_06_03_NOON_UTC - 86_400_000L,
+				MON_2024_06_03_NOON_UTC + 86_400_000L);
+		Calendar weekend = calendarFor("weekend", false, false, false, false, false, true, true,
+				MON_2024_06_03_NOON_UTC - 86_400_000L,
+				MON_2024_06_03_NOON_UTC + 86_400_000L);
+		when(dbConfig.getCalendars()).thenReturn(Arrays.asList(weekday, weekend));
+
+		ServiceUtils utils = new ServiceUtils(dbConfig);
+		List<String> ids = utils.getServiceIdsForDayNoCache(new Date(MON_2024_06_03_NOON_UTC));
+
+		assertThat(ids).containsExactly("weekday");
+	}
+
+	@Test
+	public void getServiceIdsForDayNoCache_fallsBackToMostRecentWhenAllExpired() {
+		// Both calendars are expired; the more-recent one should still be used.
+		long target = MON_2024_06_03_NOON_UTC;
+		Calendar expiredOld = calendarFor("old", true, true, true, true, true, true, true,
+				target - 30L * 86_400_000L, target - 20L * 86_400_000L);
+		Calendar expiredRecent = calendarFor("recent", true, true, true, true, true, true, true,
+				target - 10L * 86_400_000L, target - 1L * 86_400_000L);
+		when(dbConfig.getCalendars()).thenReturn(Arrays.asList(expiredOld, expiredRecent));
+
+		ServiceUtils utils = new ServiceUtils(dbConfig);
+		List<String> ids = utils.getServiceIdsForDayNoCache(new Date(target));
+
+		assertThat(ids).containsExactly("recent");
+	}
+
+	@Test
+	public void getServiceIdsForDayNoCache_calendarDateAddsService() {
+		Calendar weekday = calendarFor("weekday", true, true, true, true, true, false, false,
+				MON_2024_06_03_NOON_UTC - 86_400_000L,
+				MON_2024_06_03_NOON_UTC + 86_400_000L);
+		when(dbConfig.getCalendars()).thenReturn(Collections.singletonList(weekday));
+
+		CalendarDate addHoliday = mock(CalendarDate.class);
+		when(addHoliday.addService()).thenReturn(true);
+		when(addHoliday.getServiceId()).thenReturn("holiday-extra");
+		when(dbConfig.getCalendarDates(any(Date.class)))
+				.thenReturn(Collections.singletonList(addHoliday));
+
+		ServiceUtils utils = new ServiceUtils(dbConfig);
+		List<String> ids = utils.getServiceIdsForDayNoCache(new Date(MON_2024_06_03_NOON_UTC));
+
+		assertThat(ids).containsExactlyInAnyOrder("weekday", "holiday-extra");
+	}
+
+	@Test
+	public void getServiceIdsForDayNoCache_calendarDateRemovesService() {
+		Calendar weekday = calendarFor("weekday", true, true, true, true, true, false, false,
+				MON_2024_06_03_NOON_UTC - 86_400_000L,
+				MON_2024_06_03_NOON_UTC + 86_400_000L);
+		when(dbConfig.getCalendars()).thenReturn(Collections.singletonList(weekday));
+
+		CalendarDate removeHoliday = mock(CalendarDate.class);
+		when(removeHoliday.addService()).thenReturn(false);
+		when(removeHoliday.getServiceId()).thenReturn("weekday");
+		when(dbConfig.getCalendarDates(any(Date.class)))
+				.thenReturn(Collections.singletonList(removeHoliday));
+
+		ServiceUtils utils = new ServiceUtils(dbConfig);
+		List<String> ids = utils.getServiceIdsForDayNoCache(new Date(MON_2024_06_03_NOON_UTC));
+
+		assertThat(ids).isEmpty();
+	}
+
+	@Test
+	public void getServiceIdsForDay_cachesBySameServiceDate() {
+		Calendar weekday = calendarFor("weekday", true, true, true, true, true, false, false,
+				MON_2024_06_03_NOON_UTC - 86_400_000L,
+				MON_2024_06_03_NOON_UTC + 86_400_000L);
+		when(dbConfig.getCalendars()).thenReturn(Collections.singletonList(weekday));
+
+		ServiceUtils utils = new ServiceUtils(dbConfig);
+		List<String> first = utils.getServiceIdsForDay(new Date(MON_2024_06_03_NOON_UTC));
+		List<String> second = utils.getServiceIdsForDay(
+				new Date(MON_2024_06_03_NOON_UTC + 3_600_000L)); // same day, later hour
+
+		assertThat(first).containsExactly("weekday");
+		assertThat(second).isSameAs(first); // cache returns the exact same list instance
+	}
+
+	@Test
+	public void getServiceIdsForDay_longOverloadDelegates() {
+		Calendar weekday = calendarFor("weekday", true, true, true, true, true, false, false,
+				MON_2024_06_03_NOON_UTC - 86_400_000L,
+				MON_2024_06_03_NOON_UTC + 86_400_000L);
+		when(dbConfig.getCalendars()).thenReturn(Collections.singletonList(weekday));
+
+		ServiceUtils utils = new ServiceUtils(dbConfig);
+
+		assertThat(utils.getServiceIdsForDay(MON_2024_06_03_NOON_UTC))
+				.containsExactly("weekday");
+	}
+
+	private static Calendar calendarFor(String serviceId,
+			boolean mon, boolean tue, boolean wed, boolean thu, boolean fri,
+			boolean sat, boolean sun,
+			long startEpochMs, long endEpochMs) {
+		Calendar c = mock(Calendar.class);
+		when(c.getServiceId()).thenReturn(serviceId);
+		when(c.getMonday()).thenReturn(mon);
+		when(c.getTuesday()).thenReturn(tue);
+		when(c.getWednesday()).thenReturn(wed);
+		when(c.getThursday()).thenReturn(thu);
+		when(c.getFriday()).thenReturn(fri);
+		when(c.getSaturday()).thenReturn(sat);
+		when(c.getSunday()).thenReturn(sun);
+		when(c.getStartDate()).thenReturn(new Date(startEpochMs));
+		when(c.getEndDate()).thenReturn(new Date(endEpochMs));
+		return c;
+	}
+}

--- a/transitclock/src/test/java/org/transitclock/core/SpatialMatchTest.java
+++ b/transitclock/src/test/java/org/transitclock/core/SpatialMatchTest.java
@@ -1,0 +1,321 @@
+package org.transitclock.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.junit.Test;
+import org.transitclock.db.structs.Block;
+import org.transitclock.db.structs.Location;
+import org.transitclock.db.structs.StopPath;
+import org.transitclock.db.structs.Trip;
+import org.transitclock.db.structs.TripPattern;
+import org.transitclock.db.structs.VectorWithHeading;
+
+public class SpatialMatchTest {
+
+	/**
+	 * Builds a block with one Trip containing {@code numStopPaths} stop paths,
+	 * each a single 200m segment, non-layover, with beforeStopDistance=50 and
+	 * afterStopDistance=50.
+	 */
+	private static Block buildSimpleBlock(int numStopPaths,
+			boolean[] layoverFlags) {
+		Block block = mock(Block.class);
+		Trip trip = mock(Trip.class);
+		TripPattern tripPattern = mock(TripPattern.class);
+
+		VectorWithHeading segment = new VectorWithHeading(
+				new Location(0.0, 0.0), new Location(0.0, 0.002)); // ~222m east
+		double segLen = segment.length();
+
+		for (int i = 0; i < numStopPaths; i++) {
+			StopPath sp = mock(StopPath.class);
+			when(sp.getNumberSegments()).thenReturn(1);
+			when(sp.getSegmentVector(0)).thenReturn(segment);
+			when(sp.getSegmentVectors()).thenReturn(Collections.singletonList(segment));
+			when(sp.getLength()).thenReturn(segLen);
+			when(sp.getBeforeStopDistance()).thenReturn(50.0);
+			when(sp.getAfterStopDistance()).thenReturn(50.0);
+			when(sp.isLayoverStop()).thenReturn(layoverFlags != null && layoverFlags[i]);
+			when(sp.getStopId()).thenReturn("stop-" + i);
+			when(sp.getGtfsStopSeq()).thenReturn(i);
+			when(block.getStopPath(0, i)).thenReturn(sp);
+			when(block.isLayover(0, i)).thenReturn(layoverFlags != null && layoverFlags[i]);
+			when(block.isWaitStop(0, i)).thenReturn(false);
+			when(block.numSegments(0, i)).thenReturn(1);
+			when(block.getSegmentVector(0, i, 0)).thenReturn(segment);
+			when(trip.getStopPath(i)).thenReturn(sp);
+			when(tripPattern.getStopPath(i)).thenReturn(sp);
+		}
+		when(trip.getBlock()).thenReturn(block);
+		when(trip.getTripPattern()).thenReturn(tripPattern);
+		when(trip.getNumberStopPaths()).thenReturn(numStopPaths);
+		when(trip.getLength()).thenReturn(segLen * numStopPaths);
+
+		when(block.getTrips()).thenReturn(Collections.singletonList(trip));
+		when(block.getTrip(0)).thenReturn(trip);
+		when(block.numTrips()).thenReturn(1);
+		when(block.numStopPaths(0)).thenReturn(numStopPaths);
+		when(block.isNoSchedule()).thenReturn(false);
+		when(block.getId()).thenReturn("block-1");
+		return block;
+	}
+
+	private static SpatialMatch matchAt(Block block, int stopPathIndex,
+			double distanceAlongSegment) {
+		return new SpatialMatch(1_700_000_000_000L, block,
+				/* tripIndex */ 0, stopPathIndex,
+				/* segmentIndex */ 0,
+				/* distanceToSegment */ 0.0,
+				distanceAlongSegment);
+	}
+
+	@Test
+	public void getters_reflectConstructorArgs() {
+		Block block = buildSimpleBlock(2, null);
+		SpatialMatch match = matchAt(block, 0, 50.0);
+
+		assertThat(match.getAvlTime()).isEqualTo(1_700_000_000_000L);
+		assertThat(match.getBlock()).isSameAs(block);
+		assertThat(match.getTripIndex()).isEqualTo(0);
+		assertThat(match.getStopPathIndex()).isEqualTo(0);
+		assertThat(match.getSegmentIndex()).isEqualTo(0);
+		assertThat(match.getDistanceAlongSegment()).isCloseTo(50.0, within(1e-9));
+		assertThat(match.getDistanceToSegment()).isCloseTo(0.0, within(1e-9));
+		assertThat(match.getLocation()).isNotNull();
+	}
+
+	@Test
+	public void distanceAlongStopPath_equalsDistanceAlongSegmentWhenOnFirstSegment() {
+		Block block = buildSimpleBlock(2, null);
+		SpatialMatch match = matchAt(block, 0, 60.0);
+
+		assertThat(match.getDistanceAlongStopPath()).isCloseTo(60.0, within(1e-9));
+	}
+
+	@Test
+	public void distanceRemainingInStopPath_isSegmentLengthMinusProgress() {
+		Block block = buildSimpleBlock(2, null);
+		// Grab the segment length the helper used.
+		VectorWithHeading seg = block.getStopPath(0, 0).getSegmentVector(0);
+		SpatialMatch match = matchAt(block, 0, 30.0);
+
+		assertThat(match.getDistanceRemainingInStopPath())
+				.isCloseTo(seg.length() - 30.0, within(1e-9));
+	}
+
+	@Test
+	public void atStop_nearEndOfPathIsAtStop() {
+		Block block = buildSimpleBlock(2, null);
+		VectorWithHeading seg = block.getStopPath(0, 0).getSegmentVector(0);
+		// 10m from end → well within the 50m beforeStopDistance.
+		SpatialMatch match = matchAt(block, 0, seg.length() - 10.0);
+
+		assertThat(match.isAtStop()).isTrue();
+		assertThat(match.atEndOfPathStop()).isTrue();
+		assertThat(match.getAtEndStop()).isNotNull();
+		assertThat(match.getAtBeginningStop()).isNull();
+	}
+
+	@Test
+	public void atStop_justAfterPreviousStopIsAtBeginningStop() {
+		Block block = buildSimpleBlock(2, null);
+		// 10m into stopPath 1 → within afterStopDistance from the boundary.
+		SpatialMatch match = matchAt(block, 1, 10.0);
+
+		assertThat(match.isAtStop()).isTrue();
+		assertThat(match.atBeginningOfPathStop()).isTrue();
+		assertThat(match.atEndOfPathStop()).isFalse();
+		assertThat(match.getAtBeginningStop()).isNotNull();
+		assertThat(match.getAtEndStop()).isNull();
+	}
+
+	@Test
+	public void atStop_inMiddleOfPathIsNotAtStop() {
+		Block block = buildSimpleBlock(2, null);
+		VectorWithHeading seg = block.getStopPath(0, 0).getSegmentVector(0);
+		// Midway through segment, far from both 50m boundaries.
+		SpatialMatch match = matchAt(block, 0, seg.length() / 2.0);
+
+		assertThat(match.isAtStop()).isFalse();
+		assertThat(match.getAtStop()).isNull();
+		assertThat(match.atEndOfPathStop()).isFalse();
+		assertThat(match.atBeginningOfPathStop()).isFalse();
+	}
+
+	@Test
+	public void atStop_layoverStopAlwaysCountsAsAtStop() {
+		// Layover flag forces atStop regardless of how far from the stop we are.
+		Block block = buildSimpleBlock(2, new boolean[] {true, false});
+		SpatialMatch match = matchAt(block, 0, 5.0); // almost at the start
+
+		assertThat(match.isAtStop()).isTrue();
+		assertThat(match.atEndOfPathStop()).isTrue();
+	}
+
+	@Test
+	public void isLastTripOfBlock_trueOnlyOnFinalTrip() {
+		// buildSimpleBlock only has one trip, so tripIndex 0 is the last trip.
+		Block block = buildSimpleBlock(1, null);
+		SpatialMatch match = matchAt(block, 0, 10.0);
+		assertThat(match.isLastTripOfBlock()).isTrue();
+	}
+
+	@Test
+	public void isLastTripOfBlock_falseWhenMoreTripsFollow() {
+		Block block = buildSimpleBlock(1, null);
+		Trip firstTrip = block.getTrips().get(0);
+		// Pretend block has two trips; tripIndex 0 is not the last.
+		Trip secondTrip = mock(Trip.class);
+		when(block.getTrips()).thenReturn(Arrays.asList(firstTrip, secondTrip));
+
+		SpatialMatch match = matchAt(block, 0, 10.0);
+		assertThat(match.isLastTripOfBlock()).isFalse();
+	}
+
+	@Test
+	public void lessThan_comparesByTripStopSegmentThenDistance() {
+		Block block = buildSimpleBlock(3, null);
+		SpatialMatch earlier = matchAt(block, 0, 50.0);
+		SpatialMatch later = matchAt(block, 1, 10.0);
+		SpatialMatch same = matchAt(block, 0, 50.0);
+
+		assertThat(earlier.lessThan(later)).isTrue();
+		assertThat(later.lessThan(earlier)).isFalse();
+		assertThat(earlier.lessThan(same)).isFalse(); // strict
+		assertThat(earlier.lessThanOrEqualTo(same)).isTrue();
+	}
+
+	@Test
+	public void lessThan_comparesByDistanceAlongSegmentWhenIndicesEqual() {
+		Block block = buildSimpleBlock(2, null);
+		SpatialMatch a = matchAt(block, 0, 30.0);
+		SpatialMatch b = matchAt(block, 0, 60.0);
+
+		assertThat(a.lessThan(b)).isTrue();
+		assertThat(b.lessThan(a)).isFalse();
+	}
+
+	@Test
+	public void numberStopsBetweenMatches_singleTripCountsStopPathsTraversed() {
+		Block block = buildSimpleBlock(4, null);
+		SpatialMatch m1 = matchAt(block, 1, 10.0);
+		SpatialMatch m2 = matchAt(block, 3, 5.0);
+
+		assertThat(SpatialMatch.numberStopsBetweenMatches(m1, m2)).isEqualTo(2);
+	}
+
+	@Test
+	public void numberStopsBetweenMatches_crossingTripIncludesIntermediateStops() {
+		// numberStopsBetweenMatches is static and only calls block.getTrip(i)
+		// and getNumberStopPaths on it, so a minimal mock is enough.
+		Block block = mock(Block.class);
+		Trip firstTrip = mock(Trip.class);
+		when(firstTrip.getNumberStopPaths()).thenReturn(5);
+		Trip secondTrip = mock(Trip.class);
+		when(secondTrip.getNumberStopPaths()).thenReturn(7);
+		when(block.getTrip(0)).thenReturn(firstTrip);
+		when(block.getTrip(1)).thenReturn(secondTrip);
+		when(block.getId()).thenReturn("block-1");
+
+		SpatialMatch m1 = mock(SpatialMatch.class);
+		when(m1.getTripIndex()).thenReturn(0);
+		when(m1.getStopPathIndex()).thenReturn(2);
+		SpatialMatch m2 = mock(SpatialMatch.class);
+		when(m2.getTripIndex()).thenReturn(1);
+		when(m2.getStopPathIndex()).thenReturn(3);
+		when(m2.getBlock()).thenReturn(block);
+
+		// Formula in class: (stopIdxInLastTrip - stopIdxInFirstTrip)
+		//                 + sum(numberStopPaths for intermediate trips)
+		// (3 - 2) + 5 = 6.
+		assertThat(SpatialMatch.numberStopsBetweenMatches(m1, m2)).isEqualTo(6);
+	}
+
+	@Test
+	public void isAtStopByTripAndPath_matchesWhenAtSpecifiedStop() {
+		Block block = buildSimpleBlock(2, null);
+		VectorWithHeading seg = block.getStopPath(0, 0).getSegmentVector(0);
+		SpatialMatch match = matchAt(block, 0, seg.length() - 10.0);
+
+		assertThat(match.isAtStop(0, 0)).isTrue();
+		assertThat(match.isAtStop(0, 1)).isFalse();
+	}
+
+	@Test
+	public void isLayoverAndWaitStop_delegateToBlock() {
+		Block block = buildSimpleBlock(2, null);
+		when(block.isLayover(0, 1)).thenReturn(true);
+		when(block.isWaitStop(0, 1)).thenReturn(true);
+
+		SpatialMatch match = matchAt(block, 1, 50.0);
+
+		assertThat(match.isLayover()).isTrue();
+		assertThat(match.isWaitStop()).isTrue();
+	}
+
+	@Test
+	public void isLayover_falseForNoScheduleBlocks() {
+		// Frequency-based unscheduled blocks can't have layovers even if the
+		// underlying stop path is flagged.
+		Block block = buildSimpleBlock(2, new boolean[] {true, false});
+		when(block.isNoSchedule()).thenReturn(true);
+		// Use a non-at-stop position to avoid the layover-implies-at-stop branch.
+		VectorWithHeading seg = block.getStopPath(0, 0).getSegmentVector(0);
+		// Need a match away from layover to observe isLayover() — but the
+		// constructor treats layovers as always-at-stop, that's fine; isLayover
+		// returns false independently because isNoSchedule short-circuits.
+		SpatialMatch match = new SpatialMatch(0, block, 0, 1, 0, 0.0, seg.length() / 2);
+
+		assertThat(match.isLayover()).isFalse();
+	}
+
+	@Test
+	public void getIndices_returnsIndependentIndicesInstance() {
+		Block block = buildSimpleBlock(3, null);
+		SpatialMatch match = matchAt(block, 1, 50.0);
+
+		Indices a = match.getIndices();
+		Indices b = match.getIndices();
+
+		assertThat(a).isNotSameAs(b);
+		assertThat(a.getTripIndex()).isEqualTo(0);
+		assertThat(a.getStopPathIndex()).isEqualTo(1);
+	}
+
+	@Test
+	public void getStopPath_delegatesToTrip() {
+		Block block = buildSimpleBlock(2, null);
+		SpatialMatch match = matchAt(block, 1, 20.0);
+
+		assertThat(match.getStopPath()).isSameAs(block.getTrip(0).getStopPath(1));
+	}
+
+	@Test
+	public void getSegmentVector_returnsLastSegmentOfCurrentStopPath() {
+		// When there's only one segment per path the "last segment" is that one.
+		Block block = buildSimpleBlock(2, null);
+		SpatialMatch match = matchAt(block, 0, 30.0);
+
+		assertThat(match.getSegmentVector())
+				.isSameAs(block.getSegmentVector(0, 0, 0));
+	}
+
+	@Test
+	public void getScheduledWaitStopTimeSecs_returnsMinusOneOnException() {
+		Block block = buildSimpleBlock(2, null);
+		when(block.getScheduleTime(anyInt(), anyInt()))
+				.thenThrow(new RuntimeException("no schedule time"));
+
+		SpatialMatch match = matchAt(block, 0, 50.0);
+
+		assertThat(match.getScheduledWaitStopTimeSecs()).isEqualTo(-1);
+		assertThat(match.getScheduledWaitStopTime()).isEqualTo(-1);
+	}
+}

--- a/transitclock/src/test/java/org/transitclock/core/SpatialMatchTest.java
+++ b/transitclock/src/test/java/org/transitclock/core/SpatialMatchTest.java
@@ -152,8 +152,13 @@ public class SpatialMatchTest {
 	@Test
 	public void atStop_layoverStopAlwaysCountsAsAtStop() {
 		// Layover flag forces atStop regardless of how far from the stop we are.
+		// Position the match at the midpoint of the segment — outside both
+		// beforeStopDistance (50m from end) and afterStopDistance (50m from
+		// start) — so the only thing that can drive isAtStop to true is the
+		// layover flag itself.
 		Block block = buildSimpleBlock(2, new boolean[] {true, false});
-		SpatialMatch match = matchAt(block, 0, 5.0); // almost at the start
+		VectorWithHeading seg = block.getStopPath(0, 0).getSegmentVector(0);
+		SpatialMatch match = matchAt(block, 0, seg.length() / 2.0);
 
 		assertThat(match.isAtStop()).isTrue();
 		assertThat(match.atEndOfPathStop()).isTrue();

--- a/transitclock/src/test/java/org/transitclock/core/SpatialMatcherTest.java
+++ b/transitclock/src/test/java/org/transitclock/core/SpatialMatcherTest.java
@@ -1,0 +1,99 @@
+package org.transitclock.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+
+import org.junit.Test;
+import org.transitclock.core.SpatialMatcher.MatchingType;
+import org.transitclock.db.structs.AvlReport;
+import org.transitclock.db.structs.Block;
+import org.transitclock.db.structs.Trip;
+
+public class SpatialMatcherTest {
+
+	@Test
+	public void problemMatch_nullMatchReturnsFalse() {
+		assertThat(SpatialMatcher.problemMatchDueToLackOfHeadingInfo(
+				null, mock(VehicleState.class), MatchingType.STANDARD_MATCHING))
+				.isFalse();
+	}
+
+	@Test
+	public void problemMatch_layoverShortCircuitsToFalse() {
+		SpatialMatch match = mock(SpatialMatch.class);
+		when(match.isLayover()).thenReturn(true);
+		Trip trip = mock(Trip.class);
+		when(match.getTrip()).thenReturn(trip);
+
+		VehicleState vs = mock(VehicleState.class);
+		AvlReport avl = mock(AvlReport.class);
+		when(vs.getAvlReport()).thenReturn(avl);
+
+		assertThat(SpatialMatcher.problemMatchDueToLackOfHeadingInfo(
+				match, vs, MatchingType.STANDARD_MATCHING)).isFalse();
+	}
+
+	@Test
+	public void problemMatch_validHeadingShortCircuitsToFalse() {
+		SpatialMatch match = mock(SpatialMatch.class);
+		when(match.isLayover()).thenReturn(false);
+		Trip trip = mock(Trip.class);
+		when(match.getTrip()).thenReturn(trip);
+
+		VehicleState vs = mock(VehicleState.class);
+		AvlReport avl = mock(AvlReport.class);
+		when(avl.getHeading()).thenReturn(180.0f); // non-NaN → heading is valid
+		when(vs.getAvlReport()).thenReturn(avl);
+
+		assertThat(SpatialMatcher.problemMatchDueToLackOfHeadingInfo(
+				match, vs, MatchingType.STANDARD_MATCHING)).isFalse();
+	}
+
+	@Test
+	public void problemMatch_noHeadingAndNoPreviousAvlReportIsAProblem() {
+		SpatialMatch match = mock(SpatialMatch.class);
+		when(match.isLayover()).thenReturn(false);
+		Trip trip = mock(Trip.class);
+		when(match.getTrip()).thenReturn(trip);
+
+		VehicleState vs = mock(VehicleState.class);
+		AvlReport avl = mock(AvlReport.class);
+		when(avl.getHeading()).thenReturn(Float.NaN);
+		when(vs.getAvlReport()).thenReturn(avl);
+		// No previous AVL report far enough back → can't confirm direction.
+		when(vs.getPreviousAvlReport(org.mockito.ArgumentMatchers.anyDouble()))
+				.thenReturn(null);
+
+		assertThat(SpatialMatcher.problemMatchDueToLackOfHeadingInfo(
+				match, vs, MatchingType.STANDARD_MATCHING)).isTrue();
+	}
+
+	@Test
+	public void getSpatialMatches_nullTripListReturnsEmpty() {
+		AvlReport avl = mock(AvlReport.class);
+		Block block = mock(Block.class);
+
+		assertThat(SpatialMatcher.getSpatialMatches(avl, block, null,
+				MatchingType.STANDARD_MATCHING)).isEmpty();
+	}
+
+	@Test
+	public void getSpatialMatches_emptyTripListReturnsEmpty() {
+		AvlReport avl = mock(AvlReport.class);
+		Block block = mock(Block.class);
+
+		assertThat(SpatialMatcher.getSpatialMatches(avl, block,
+				Collections.emptyList(), MatchingType.STANDARD_MATCHING)).isEmpty();
+	}
+
+	@Test
+	public void matchingType_enumValuesAreStable() {
+		// Ordinals/values are part of the persisted/public API surface.
+		assertThat(MatchingType.values())
+				.containsExactly(MatchingType.STANDARD_MATCHING,
+						MatchingType.AUTO_ASSIGNING_MATCHING);
+	}
+}

--- a/transitclock/src/test/java/org/transitclock/core/TemporalMatcherTest.java
+++ b/transitclock/src/test/java/org/transitclock/core/TemporalMatcherTest.java
@@ -1,0 +1,110 @@
+package org.transitclock.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.Date;
+
+import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.transitclock.applications.Core;
+import org.transitclock.db.structs.AvlReport;
+import org.transitclock.db.structs.Block;
+import org.transitclock.db.structs.Location;
+import org.transitclock.db.structs.StopPath;
+import org.transitclock.db.structs.Trip;
+import org.transitclock.utils.Time;
+
+public class TemporalMatcherTest {
+
+	@Test
+	public void getInstance_returnsSingleton() {
+		assertThat(TemporalMatcher.getInstance())
+				.isNotNull()
+				.isSameAs(TemporalMatcher.getInstance());
+	}
+
+	@Test
+	public void matchToLayoverStopEvenIfOffRoute_emptyPotentialTripsReturnsNull() {
+		AvlReport avl = mock(AvlReport.class);
+
+		Trip result = TemporalMatcher.getInstance()
+				.matchToLayoverStopEvenIfOffRoute(avl, Collections.emptyList());
+
+		assertThat(result).isNull();
+	}
+
+	@Test
+	public void matchToLayoverStopEvenIfOffRoute_returnsTripReachableByDeadhead() {
+		// AVL at 07:59 UTC, trip starts at 08:00. Distance to the trip start is
+		// tiny, so as-the-crow-flies travel time will fit inside that minute.
+		long avlEpoch = 1_700_000_000_000L;
+		int tripStartSecs = 1_000; // arbitrary secs into day
+		long msecsIntoDay = tripStartSecs * 1000L - 60_000L; // 60s before start
+
+		AvlReport avl = mock(AvlReport.class);
+		when(avl.getDate()).thenReturn(new Date(avlEpoch));
+		when(avl.getLocation()).thenReturn(new Location(47.6000, -122.3000));
+		when(avl.getVehicleId()).thenReturn("veh-1");
+
+		Trip trip = mock(Trip.class);
+		when(trip.getStartTime()).thenReturn(tripStartSecs);
+		StopPath firstStop = mock(StopPath.class);
+		when(firstStop.getEndOfPathLocation())
+				.thenReturn(new Location(47.6001, -122.3000)); // ~10m away
+		when(trip.getStopPath(0)).thenReturn(firstStop);
+		Block block = mock(Block.class);
+		when(trip.getBlock()).thenReturn(block);
+		when(trip.getIndexInBlock()).thenReturn(0);
+		when(trip.getId()).thenReturn("trip-1");
+
+		try (MockedStatic<Core> coreMock = mockStatic(Core.class)) {
+			Time time = mock(Time.class);
+			when(time.getMsecsIntoDay(any(Date.class), anyLong())).thenReturn(msecsIntoDay);
+			Core core = mock(Core.class);
+			when(core.getTime()).thenReturn(time);
+			coreMock.when(Core::getInstance).thenReturn(core);
+
+			Trip result = TemporalMatcher.getInstance()
+					.matchToLayoverStopEvenIfOffRoute(avl, Collections.singletonList(trip));
+
+			assertThat(result).isSameAs(trip);
+		}
+	}
+
+	@Test
+	public void matchToLayoverStopEvenIfOffRoute_tripAlreadyStartedReturnsNull() {
+		// If AVL time is after trip start, vehicle can't deadhead — method skips.
+		long avlEpoch = 1_700_000_000_000L;
+		int tripStartSecs = 1_000;
+		// msecsIntoDay > tripStartTimeMsecs → the "not in future" branch.
+		long msecsIntoDay = tripStartSecs * 1000L + 60_000L;
+
+		AvlReport avl = mock(AvlReport.class);
+		when(avl.getDate()).thenReturn(new Date(avlEpoch));
+		when(avl.getVehicleId()).thenReturn("veh-1");
+
+		Trip trip = mock(Trip.class);
+		when(trip.getStartTime()).thenReturn(tripStartSecs);
+		when(trip.getIndexInBlock()).thenReturn(0);
+		when(trip.getId()).thenReturn("trip-1");
+
+		try (MockedStatic<Core> coreMock = mockStatic(Core.class)) {
+			Time time = mock(Time.class);
+			when(time.getMsecsIntoDay(any(Date.class), anyLong())).thenReturn(msecsIntoDay);
+			Core core = mock(Core.class);
+			when(core.getTime()).thenReturn(time);
+			coreMock.when(Core::getInstance).thenReturn(core);
+
+			Trip result = TemporalMatcher.getInstance()
+					.matchToLayoverStopEvenIfOffRoute(avl, Collections.singletonList(trip));
+
+			assertThat(result).isNull();
+		}
+	}
+}

--- a/transitclock/src/test/java/org/transitclock/core/TravelTimesTest.java
+++ b/transitclock/src/test/java/org/transitclock/core/TravelTimesTest.java
@@ -1,0 +1,145 @@
+package org.transitclock.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.Test;
+import org.transitclock.configData.CoreConfig;
+import org.transitclock.db.structs.Location;
+import org.transitclock.db.structs.StopPath;
+import org.transitclock.db.structs.TravelTimesForStopPath;
+import org.transitclock.db.structs.Trip;
+
+public class TravelTimesTest {
+
+	@Test
+	public void getInstance_returnsSingleton() {
+		TravelTimes a = TravelTimes.getInstance();
+		TravelTimes b = TravelTimes.getInstance();
+		assertThat(a).isNotNull().isSameAs(b);
+	}
+
+	@Test
+	public void travelTimeAsTheCrowFlies_shortDistanceUsesShortSpeed() {
+		float shortSpeed = CoreConfig.getShortDistanceDeadheadingSpeed();
+		float cutoff = CoreConfig.getDeadheadingShortVersusLongDistance();
+		double distance = cutoff / 2.0; // below the cutoff → short speed only
+		int expectedMsec = (int) ((distance / shortSpeed) * 1000);
+
+		int actual = TravelTimes.travelTimeAsTheCrowFlies(distance);
+
+		assertThat(actual).isEqualTo(expectedMsec);
+	}
+
+	@Test
+	public void travelTimeAsTheCrowFlies_longDistanceCombinesBothSpeeds() {
+		float shortSpeed = CoreConfig.getShortDistanceDeadheadingSpeed();
+		float longSpeed = CoreConfig.getLongDistanceDeadheadingSpeed();
+		float cutoff = CoreConfig.getDeadheadingShortVersusLongDistance();
+		double distance = cutoff * 3.0;
+
+		double expectedSecs = cutoff / shortSpeed + (distance - cutoff) / longSpeed;
+		int expectedMsec = (int) (expectedSecs * 1000);
+
+		int actual = TravelTimes.travelTimeAsTheCrowFlies(distance);
+
+		assertThat(actual).isEqualTo(expectedMsec);
+	}
+
+	@Test
+	public void travelTimeAsTheCrowFlies_exactCutoffTreatsAsShort() {
+		// distance == cutoff falls into the `else` branch (shortDistanceTravel=distance, long=0).
+		float shortSpeed = CoreConfig.getShortDistanceDeadheadingSpeed();
+		float cutoff = CoreConfig.getDeadheadingShortVersusLongDistance();
+		int expectedMsec = (int) ((cutoff / shortSpeed) * 1000);
+
+		assertThat(TravelTimes.travelTimeAsTheCrowFlies(cutoff)).isEqualTo(expectedMsec);
+	}
+
+	@Test
+	public void travelTimeAsTheCrowFlies_zeroDistanceReturnsZero() {
+		assertThat(TravelTimes.travelTimeAsTheCrowFlies(0)).isEqualTo(0);
+	}
+
+	@Test
+	public void travelTimeFromLayoverArrivalToNewLoc_nonLayoverReturnsZero() {
+		SpatialMatch match = mock(SpatialMatch.class);
+		when(match.isLayover()).thenReturn(false);
+
+		int result = TravelTimes.travelTimeFromLayoverArrivalToNewLoc(
+				match, new Location(0.0, 0.0));
+
+		assertThat(result).isEqualTo(0);
+	}
+
+	@Test
+	public void travelTimeFromLayoverArrivalToNewLoc_noPreviousStopReturnsZero() {
+		SpatialMatch match = mock(SpatialMatch.class);
+		when(match.isLayover()).thenReturn(true);
+		when(match.getMatchAtPreviousStop()).thenReturn(null);
+
+		int result = TravelTimes.travelTimeFromLayoverArrivalToNewLoc(
+				match, new Location(47.6, -122.3));
+
+		assertThat(result).isEqualTo(0);
+	}
+
+	@Test
+	public void travelTimeFromLayoverArrivalToNewLoc_computesCrowFliesFromPreviousStop() {
+		// Build a previous-stop match whose stopPath ends at a known location.
+		Location endOfPrevTrip = new Location(47.6000, -122.3000);
+		Location newLoc = new Location(47.6100, -122.3000); // ~1.1km north
+
+		StopPath prevStopPath = mock(StopPath.class);
+		when(prevStopPath.getEndOfPathLocation()).thenReturn(endOfPrevTrip);
+
+		SpatialMatch prevMatch = mock(SpatialMatch.class);
+		when(prevMatch.getStopPath()).thenReturn(prevStopPath);
+
+		SpatialMatch match = mock(SpatialMatch.class);
+		when(match.isLayover()).thenReturn(true);
+		when(match.getMatchAtPreviousStop()).thenReturn(prevMatch);
+
+		int result = TravelTimes.travelTimeFromLayoverArrivalToNewLoc(match, newLoc);
+
+		// Should match the pure-function crow-flies travel time for that distance.
+		double distance = endOfPrevTrip.distance(newLoc);
+		int expected = TravelTimes.travelTimeAsTheCrowFlies(distance);
+		assertThat(result).isEqualTo(expected).isPositive();
+	}
+
+	@Test
+	public void expectedTravelTimeForStopPath_returnsStopPathTravelTimeFromTrip() {
+		TravelTimesForStopPath ttsp = mock(TravelTimesForStopPath.class);
+		when(ttsp.getStopPathTravelTimeMsec()).thenReturn(60_000);
+
+		Trip trip = mock(Trip.class);
+		when(trip.getTravelTimesForStopPath(3)).thenReturn(ttsp);
+
+		Indices indices = mock(Indices.class);
+		when(indices.getTrip()).thenReturn(trip);
+		when(indices.getStopPathIndex()).thenReturn(3);
+
+		int result = TravelTimes.getInstance().expectedTravelTimeForStopPath(indices);
+
+		assertThat(result).isEqualTo(60_000);
+	}
+
+	@Test
+	public void expectedStopTimeForStopPath_returnsStopTimeFromTrip() {
+		TravelTimesForStopPath ttsp = mock(TravelTimesForStopPath.class);
+		when(ttsp.getStopTimeMsec()).thenReturn(15_000);
+
+		Trip trip = mock(Trip.class);
+		when(trip.getTravelTimesForStopPath(0)).thenReturn(ttsp);
+
+		Indices indices = mock(Indices.class);
+		when(indices.getTrip()).thenReturn(trip);
+		when(indices.getStopPathIndex()).thenReturn(0);
+
+		int result = TravelTimes.getInstance().expectedStopTimeForStopPath(indices);
+
+		assertThat(result).isEqualTo(15_000);
+	}
+}

--- a/transitclock/src/test/java/org/transitclock/core/headwaygenerator/LastArrivalsHeadwayGeneratorTest.java
+++ b/transitclock/src/test/java/org/transitclock/core/headwaygenerator/LastArrivalsHeadwayGeneratorTest.java
@@ -1,0 +1,57 @@
+package org.transitclock.core.headwaygenerator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Test;
+import org.transitclock.core.HeadwayGenerator;
+import org.transitclock.core.VehicleState;
+import org.transitclock.db.structs.Headway;
+
+public class LastArrivalsHeadwayGeneratorTest {
+
+	@Test
+	public void implementsHeadwayGenerator() {
+		assertThat(new LastArrivalsHeadwayGenerator()).isInstanceOf(HeadwayGenerator.class);
+	}
+
+	@Test
+	public void generate_swallowsExceptionAndReturnsNull() {
+		LastArrivalsHeadwayGenerator gen = new LastArrivalsHeadwayGenerator();
+		assertThat(gen.generate(mock(VehicleState.class))).isNull();
+	}
+
+	@Test
+	public void average_variance_cov_matchHandComputedValues() throws Exception {
+		List<Headway> headways = Arrays.asList(
+				headway(60.0), headway(120.0), headway(180.0));
+
+		double avg = (Double) invokePrivate("average", List.class, headways);
+		double variance = (Double) invokePrivate("variance", List.class, headways);
+		double cov = (Double) invokePrivate("coefficientOfVariance", List.class, headways);
+
+		// mean = 120; squared deviations 60²+0²+60² = 7200; variance = 2400.
+		assertThat(avg).isCloseTo(120.0, within(1e-9));
+		assertThat(variance).isCloseTo(2400.0, within(1e-9));
+		assertThat(cov).isCloseTo(2400.0 / (120.0 * 120.0), within(1e-9));
+	}
+
+	private static Headway headway(double ms) {
+		Headway h = mock(Headway.class);
+		when(h.getHeadway()).thenReturn(ms);
+		return h;
+	}
+
+	private static Object invokePrivate(String name, Class<?> paramType, Object arg)
+			throws Exception {
+		Method m = LastArrivalsHeadwayGenerator.class.getDeclaredMethod(name, paramType);
+		m.setAccessible(true);
+		return m.invoke(new LastArrivalsHeadwayGenerator(), arg);
+	}
+}

--- a/transitclock/src/test/java/org/transitclock/core/headwaygenerator/LastDepartureHeadwayGeneratorTest.java
+++ b/transitclock/src/test/java/org/transitclock/core/headwaygenerator/LastDepartureHeadwayGeneratorTest.java
@@ -1,0 +1,79 @@
+package org.transitclock.core.headwaygenerator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Test;
+import org.transitclock.core.HeadwayGenerator;
+import org.transitclock.core.VehicleState;
+import org.transitclock.db.structs.Headway;
+
+public class LastDepartureHeadwayGeneratorTest {
+
+	@Test
+	public void implementsHeadwayGenerator() {
+		assertThat(new LastDepartureHeadwayGenerator()).isInstanceOf(HeadwayGenerator.class);
+	}
+
+	@Test
+	public void generate_swallowsExceptionAndReturnsNull() {
+		// VehicleState is a bare mock — getMatch() returns null, so the chain
+		// vehicleState.getMatch().getMatchAtPreviousStop()... will NPE. The
+		// generator catches everything and returns null.
+		LastDepartureHeadwayGenerator gen = new LastDepartureHeadwayGenerator();
+		assertThat(gen.generate(mock(VehicleState.class))).isNull();
+	}
+
+	@Test
+	public void average_isArithmeticMeanOfHeadways() throws Exception {
+		List<Headway> headways = Arrays.asList(
+				headway(100.0), headway(200.0), headway(300.0));
+
+		double avg = (Double) invokePrivate("average", List.class, headways);
+
+		assertThat(avg).isCloseTo(200.0, within(1e-9));
+	}
+
+	@Test
+	public void variance_isMeanSquaredDeviation() throws Exception {
+		// mean = 200; deviations² sum = 100²+0²+100² = 20000; /3 = 6666.667
+		List<Headway> headways = Arrays.asList(
+				headway(100.0), headway(200.0), headway(300.0));
+
+		double variance = (Double) invokePrivate("variance", List.class, headways);
+
+		assertThat(variance).isCloseTo(20000.0 / 3.0, within(1e-9));
+	}
+
+	@Test
+	public void coefficientOfVariance_isVarianceOverSquaredMean() throws Exception {
+		List<Headway> headways = Arrays.asList(
+				headway(100.0), headway(200.0), headway(300.0));
+		double expected = (20000.0 / 3.0) / (200.0 * 200.0);
+
+		double cov = (Double) invokePrivate("coefficientOfVariance", List.class, headways);
+
+		assertThat(cov).isCloseTo(expected, within(1e-9));
+	}
+
+	private static Headway headway(double ms) {
+		// Real Headway construction reaches into Core.getInstance().getDbConfig();
+		// a mock with getHeadway() stubbed is enough for the math under test.
+		Headway h = mock(Headway.class);
+		when(h.getHeadway()).thenReturn(ms);
+		return h;
+	}
+
+	private static Object invokePrivate(String name, Class<?> paramType, Object arg)
+			throws Exception {
+		Method m = LastDepartureHeadwayGenerator.class.getDeclaredMethod(name, paramType);
+		m.setAccessible(true);
+		return m.invoke(new LastDepartureHeadwayGenerator(), arg);
+	}
+}

--- a/transitclock/src/test/java/org/transitclock/core/holdingmethod/HoldingTimeGeneratorDefaultImplTest.java
+++ b/transitclock/src/test/java/org/transitclock/core/holdingmethod/HoldingTimeGeneratorDefaultImplTest.java
@@ -1,0 +1,65 @@
+package org.transitclock.core.holdingmethod;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Method;
+
+import org.junit.Test;
+
+public class HoldingTimeGeneratorDefaultImplTest {
+
+	@Test
+	public void implementsHoldingTimeGenerator() {
+		assertThat(new HoldingTimeGeneratorDefaultImpl())
+				.isInstanceOf(HoldingTimeGenerator.class);
+	}
+
+	@Test
+	public void calculateHoldingTime_threePredictionsPickWorstAverage() throws Exception {
+		// N = {11, 18, 28}, last_dep = 0, current_arr = 5, max_predictions = 3.
+		//   (11-0)/2 = 5.5  → 5
+		//   (18-0)/3 = 6
+		//   (28-0)/4 = 7    ← max
+		// holding = max(7 - (5-0), 0) = 2
+		Long[] n = {11L, 18L, 28L};
+		assertThat(invokeCalc(5L, 0L, n, 3)).isEqualTo(2L);
+	}
+
+	@Test
+	public void calculateHoldingTime_clampsNegativeResultToZero() throws Exception {
+		// N = {10}, last_dep = 0, max_predictions = 1.
+		// (10-0)/2 = 5  → worst is 5.
+		// current_arr=10 makes (current-last) > worst, so result clamps to 0.
+		Long[] n = {10L};
+		assertThat(invokeCalc(10L, 0L, n, 1)).isEqualTo(0L);
+	}
+
+	@Test
+	public void calculateHoldingTime_respectsMaxPredictions() throws Exception {
+		// With full array considered, third entry 28 wins and holding=2 (above).
+		// Capping max_predictions to 1 should only look at first element:
+		//   (11-0)/2 = 5  → worst = 5
+		// holding = max(5 - 5, 0) = 0.
+		Long[] n = {11L, 18L, 28L};
+		assertThat(invokeCalc(5L, 0L, n, 1)).isEqualTo(0L);
+	}
+
+	@Test
+	public void calculateHoldingTime_singlePredictionMatchesHandCalc() throws Exception {
+		// N={10L,14L,19L}, current=3, last_dep=0, max=3
+		//   (10-0)/2 = 5
+		//   (14-0)/3 = 4
+		//   (19-0)/4 = 4  (integer division)
+		// worst = 5; holding = max(5 - (3-0), 0) = 2.
+		Long[] n = {10L, 14L, 19L};
+		assertThat(invokeCalc(3L, 0L, n, 3)).isEqualTo(2L);
+	}
+
+	private static Long invokeCalc(long currentArr, long lastDep, Long[] n, int maxPreds)
+			throws Exception {
+		Method m = HoldingTimeGeneratorDefaultImpl.class.getDeclaredMethod(
+				"calculateHoldingTime", Long.class, Long.class, Long[].class, int.class);
+		m.setAccessible(true);
+		return (Long) m.invoke(null, currentArr, lastDep, n, maxPreds);
+	}
+}

--- a/transitclock/src/test/java/org/transitclock/core/predictiongenerator/frequency/traveltime/kalman/FrequencyKalmanPredictionGeneratorImplTest.java
+++ b/transitclock/src/test/java/org/transitclock/core/predictiongenerator/frequency/traveltime/kalman/FrequencyKalmanPredictionGeneratorImplTest.java
@@ -26,8 +26,11 @@ public class FrequencyKalmanPredictionGeneratorImplTest {
 	@Test
 	public void maxPredictionsTimeSecs_usesInheritedDefault() {
 		// Not overridden in any of the intermediate layers, so the 45-min
-		// default from PredictionGeneratorDefaultImpl still applies.
-		assertThat(PredictionGeneratorDefaultImpl.getMaxPredictionsTimeSecs())
+		// default from PredictionGeneratorDefaultImpl still applies. Assert
+		// through the Kalman class so that if a future change adds a static
+		// override on Kalman (or any intermediate layer), this test breaks
+		// instead of silently continuing to read the base-class value.
+		assertThat(KalmanPredictionGeneratorImpl.getMaxPredictionsTimeSecs())
 				.isEqualTo(45 * 60);
 	}
 }

--- a/transitclock/src/test/java/org/transitclock/core/predictiongenerator/frequency/traveltime/kalman/FrequencyKalmanPredictionGeneratorImplTest.java
+++ b/transitclock/src/test/java/org/transitclock/core/predictiongenerator/frequency/traveltime/kalman/FrequencyKalmanPredictionGeneratorImplTest.java
@@ -1,0 +1,33 @@
+package org.transitclock.core.predictiongenerator.frequency.traveltime.kalman;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+import org.transitclock.core.PredictionGeneratorDefaultImpl;
+import org.transitclock.core.predictiongenerator.PredictionComponentElementsGenerator;
+import org.transitclock.core.predictiongenerator.frequency.traveltime.average.HistoricalAveragePredictionGeneratorImpl;
+import org.transitclock.core.predictiongenerator.lastvehicle.LastVehiclePredictionGeneratorImpl;
+
+public class FrequencyKalmanPredictionGeneratorImplTest {
+
+	@Test
+	public void classHierarchy_flowsThroughHistoricalAverageAndLastVehicleToDefault() {
+		KalmanPredictionGeneratorImpl gen = new KalmanPredictionGeneratorImpl();
+
+		// Frequency Kalman is layered: Kalman → HistoricalAverage → LastVehicle
+		// → PredictionGeneratorDefaultImpl. Each layer provides fallback.
+		assertThat(gen)
+				.isInstanceOf(HistoricalAveragePredictionGeneratorImpl.class)
+				.isInstanceOf(LastVehiclePredictionGeneratorImpl.class)
+				.isInstanceOf(PredictionGeneratorDefaultImpl.class)
+				.isInstanceOf(PredictionComponentElementsGenerator.class);
+	}
+
+	@Test
+	public void maxPredictionsTimeSecs_usesInheritedDefault() {
+		// Not overridden in any of the intermediate layers, so the 45-min
+		// default from PredictionGeneratorDefaultImpl still applies.
+		assertThat(PredictionGeneratorDefaultImpl.getMaxPredictionsTimeSecs())
+				.isEqualTo(45 * 60);
+	}
+}

--- a/transitclock/src/test/java/org/transitclock/core/predictiongenerator/scheduled/traveltime/kalman/ScheduledKalmanPredictionGeneratorImplTest.java
+++ b/transitclock/src/test/java/org/transitclock/core/predictiongenerator/scheduled/traveltime/kalman/ScheduledKalmanPredictionGeneratorImplTest.java
@@ -1,0 +1,45 @@
+package org.transitclock.core.predictiongenerator.scheduled.traveltime.kalman;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.Test;
+import org.transitclock.core.Indices;
+import org.transitclock.core.PredictionGeneratorDefaultImpl;
+import org.transitclock.core.VehicleState;
+import org.transitclock.core.predictiongenerator.PredictionComponentElementsGenerator;
+import org.transitclock.db.structs.AvlReport;
+import org.transitclock.db.structs.TravelTimesForStopPath;
+import org.transitclock.db.structs.Trip;
+
+public class ScheduledKalmanPredictionGeneratorImplTest {
+
+	@Test
+	public void extendsDefaultImpl_soFallbackBehaviorIsPreserved() {
+		KalmanPredictionGeneratorImpl gen = new KalmanPredictionGeneratorImpl();
+		assertThat(gen).isInstanceOf(PredictionGeneratorDefaultImpl.class);
+		assertThat(gen).isInstanceOf(PredictionComponentElementsGenerator.class);
+	}
+
+	@Test
+	public void getStopTimeForPath_inheritedFromDefaultImpl() {
+		TravelTimesForStopPath ttsp = mock(TravelTimesForStopPath.class);
+		when(ttsp.getStopTimeMsec()).thenReturn(25_000);
+
+		Trip trip = mock(Trip.class);
+		when(trip.getTravelTimesForStopPath(1)).thenReturn(ttsp);
+
+		Indices indices = mock(Indices.class);
+		when(indices.getTrip()).thenReturn(trip);
+		when(indices.getStopPathIndex()).thenReturn(1);
+
+		KalmanPredictionGeneratorImpl gen = new KalmanPredictionGeneratorImpl();
+
+		// Not overridden on Kalman, so delegates straight through to TravelTimes.
+		long result = gen.getStopTimeForPath(indices, mock(AvlReport.class),
+				mock(VehicleState.class));
+
+		assertThat(result).isEqualTo(25_000L);
+	}
+}

--- a/transitclock/src/test/java/org/transitclock/gtfs/StopPathProcessorTest.java
+++ b/transitclock/src/test/java/org/transitclock/gtfs/StopPathProcessorTest.java
@@ -1,0 +1,42 @@
+package org.transitclock.gtfs;
+
+import java.util.Collections;
+
+import org.junit.Test;
+import org.transitclock.db.structs.Stop;
+import org.transitclock.db.structs.TripPattern;
+import org.transitclock.gtfs.gtfsStructs.GtfsShape;
+
+public class StopPathProcessorTest {
+
+	@Test
+	public void processPathSegments_withEmptyInputsIsANoOp() {
+		StopPathProcessor processor = new StopPathProcessor(
+				Collections.<GtfsShape>emptyList(),
+				Collections.<String, Stop>emptyMap(),
+				Collections.<TripPattern>emptyList(),
+				/* offsetDistance */ 0.0,
+				/* maxStopToPathDistance */ 50.0,
+				/* maxDistanceForEliminatingVertices */ 5.0,
+				/* trimPathBeforeFirstStopOfTrip */ false,
+				/* maxDistanceBetweenStops */ 1000.0,
+				/* disableSpecialLoopBackToBeginningCase */ false);
+
+		// Should walk the (empty) trip patterns and finish cleanly.
+		processor.processPathSegments();
+	}
+
+	@Test
+	public void constructor_handlesDuplicateShapeIdsAndSortsThem() {
+		GtfsShape s1 = new GtfsShape("shape-A", 47.6, -122.3, 2, 0);
+		GtfsShape s2 = new GtfsShape("shape-A", 47.6001, -122.3001, 1, 10);
+
+		// Constructor groups by shapeId and sorts each group — no patterns
+		// or stops needed to exercise that path; the call should not throw.
+		new StopPathProcessor(
+				java.util.Arrays.asList(s1, s2),
+				Collections.<String, Stop>emptyMap(),
+				Collections.<TripPattern>emptyList(),
+				0.0, 50.0, 5.0, false, 1000.0, false);
+	}
+}

--- a/transitclock/src/test/java/org/transitclock/gtfs/TitleFormatterTest.java
+++ b/transitclock/src/test/java/org/transitclock/gtfs/TitleFormatterTest.java
@@ -1,0 +1,130 @@
+package org.transitclock.gtfs;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class TitleFormatterTest {
+
+	@Rule
+	public TemporaryFolder tempFolder = new TemporaryFolder();
+
+	@Test
+	public void processTitle_nullStaysNull() {
+		TitleFormatter formatter = new TitleFormatter(null, false);
+		assertThat(formatter.processTitle(null)).isNull();
+	}
+
+	@Test
+	public void processTitle_withoutRegexFileReturnsOriginalUnchanged() {
+		// capitalize config defaults to false and no regexes are loaded, so
+		// the output is identical to the input.
+		TitleFormatter formatter = new TitleFormatter(null, false);
+
+		assertThat(formatter.processTitle("MAIN ST")).isEqualTo("MAIN ST");
+		assertThat(formatter.processTitle("")).isEqualTo("");
+	}
+
+	@Test
+	public void processTitle_appliesConfiguredRegexReplacements() throws IOException {
+		File regexFile = writeRegexFile(
+				"Bart=>BART",
+				"Us=>US");
+
+		TitleFormatter formatter = new TitleFormatter(regexFile.getAbsolutePath(), false);
+
+		assertThat(formatter.processTitle("Bart Station")).isEqualTo("BART Station");
+		assertThat(formatter.processTitle("Us Bank")).isEqualTo("US Bank");
+	}
+
+	@Test
+	public void processTitle_enforcesSpacingAroundAmpersand() throws IOException {
+		// These are the patterns in the class's Javadoc for fixing &-spacing.
+		File regexFile = writeRegexFile(
+				"&(?! )=>& ",
+				"(?<! )&=> &");
+
+		TitleFormatter formatter = new TitleFormatter(regexFile.getAbsolutePath(), false);
+
+		assertThat(formatter.processTitle("Main&Elm")).isEqualTo("Main & Elm");
+		assertThat(formatter.processTitle("Main & Elm")).isEqualTo("Main & Elm");
+	}
+
+	@Test
+	public void isReplaceTitle_matchesConfiguredReplacement() throws IOException {
+		File regexFile = writeRegexFile("Bart=>BART");
+
+		TitleFormatter formatter = new TitleFormatter(regexFile.getAbsolutePath(), false);
+
+		assertThat(formatter.isReplaceTitle("BART")).isTrue();
+		assertThat(formatter.isReplaceTitle("Bart")).isFalse();
+	}
+
+	@Test
+	public void regexFile_ignoresCommentsAndBlankLines() throws IOException {
+		File regexFile = writeRegexFile(
+				"-- dash comment",
+				"// slash comment",
+				"",
+				"   ",
+				"Bart=>BART");
+
+		TitleFormatter formatter = new TitleFormatter(regexFile.getAbsolutePath(), false);
+
+		assertThat(formatter.processTitle("Bart Station")).isEqualTo("BART Station");
+	}
+
+	@Test
+	public void regexFile_skipsLinesWithoutDelimiter() throws IOException {
+		// The "no-delimiter" line is logged as an error but should not throw,
+		// and the following valid line should still be applied.
+		File regexFile = writeRegexFile(
+				"no delimiter on this line",
+				"Bart=>BART");
+
+		TitleFormatter formatter = new TitleFormatter(regexFile.getAbsolutePath(), false);
+
+		assertThat(formatter.processTitle("Bart")).isEqualTo("BART");
+	}
+
+	@Test
+	public void missingRegexFile_constructorDoesNotThrow() {
+		// IOException on open is caught and logged; formatter should still work.
+		TitleFormatter formatter = new TitleFormatter(
+				"/does/not/exist/regex-does-not-exist.txt", false);
+
+		assertThat(formatter.processTitle("unchanged")).isEqualTo("unchanged");
+	}
+
+	@Test
+	public void logRegexesThatDidNotMakeDifference_withFlagDisabledIsNoOp() throws IOException {
+		File regexFile = writeRegexFile("Bart=>BART");
+		TitleFormatter formatter = new TitleFormatter(regexFile.getAbsolutePath(), false);
+
+		// With logging disabled, the method just logs an error and returns.
+		formatter.logRegexesThatDidNotMakeDifference();
+	}
+
+	@Test
+	public void logRegexesThatDidNotMakeDifference_withFlagEnabledCompletes() throws IOException {
+		File regexFile = writeRegexFile(
+				"Bart=>BART",
+				"Neverseen=>NOPE");
+		TitleFormatter formatter = new TitleFormatter(regexFile.getAbsolutePath(), true);
+
+		formatter.processTitle("Bart Station"); // first regex used, second isn't
+		formatter.logRegexesThatDidNotMakeDifference();
+	}
+
+	private File writeRegexFile(String... lines) throws IOException {
+		File file = tempFolder.newFile("regex.txt");
+		Files.write(file.toPath(), String.join("\n", lines).getBytes());
+		return file;
+	}
+}

--- a/transitclock/src/test/java/org/transitclock/gtfs/TravelTimesProcessorForGtfsUpdatesTest.java
+++ b/transitclock/src/test/java/org/transitclock/gtfs/TravelTimesProcessorForGtfsUpdatesTest.java
@@ -1,0 +1,67 @@
+package org.transitclock.gtfs;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Test;
+import org.transitclock.db.structs.ActiveRevisions;
+import org.transitclock.db.structs.TravelTimesForTrip;
+
+public class TravelTimesProcessorForGtfsUpdatesTest {
+
+	@Test
+	public void constructor_storesInputsAndIsAccessibleViaGetters() {
+		ActiveRevisions revs = new ActiveRevisions();
+		TravelTimesProcessorForGtfsUpdates p = new TravelTimesProcessorForGtfsUpdates(
+				revs, /* originalTravelTimesRev */ 5,
+				/* maxTravelTimeSegmentLength */ 200.0,
+				/* defaultWaitTimeAtStopMsec */ 30_000,
+				/* maxSpeedKph */ 50.0);
+
+		// Nothing processed yet.
+		assertThat(p.getNumberOfTravelTimes()).isEqualTo(0);
+		assertThat(p.getOriginalNumberOfTravelTimes()).isEqualTo(0);
+	}
+
+	@Test
+	public void setNumberOfTravelTimes_nullIsIgnoredButValuesRoundTrip() {
+		TravelTimesProcessorForGtfsUpdates p = new TravelTimesProcessorForGtfsUpdates(
+				new ActiveRevisions(), 0, 200.0, 30_000, 50.0);
+
+		p.setNumberOfTravelTimes(42);
+		assertThat(p.getNumberOfTravelTimes()).isEqualTo(42);
+
+		// Null is explicitly guarded against; the prior value survives.
+		p.setNumberOfTravelTimes(null);
+		assertThat(p.getNumberOfTravelTimes()).isEqualTo(42);
+
+		p.setOriginalNumberOfTravelTimes(17);
+		assertThat(p.getOriginalNumberOfTravelTimes()).isEqualTo(17);
+	}
+
+	@Test
+	public void numberOfTravelTimes_sumsListSizesAcrossTripPatterns() throws Exception {
+		Map<String, List<TravelTimesForTrip>> map = new HashMap<>();
+		map.put("pattern-A", Arrays.asList(
+				mockTravelTimes(), mockTravelTimes(), mockTravelTimes()));
+		map.put("pattern-B", Arrays.asList(mockTravelTimes()));
+		map.put("pattern-C", Collections.<TravelTimesForTrip>emptyList());
+
+		Method m = TravelTimesProcessorForGtfsUpdates.class.getDeclaredMethod(
+				"numberOfTravelTimes", Map.class);
+		m.setAccessible(true);
+		int result = (int) m.invoke(null, map);
+
+		assertThat(result).isEqualTo(4);
+	}
+
+	private static TravelTimesForTrip mockTravelTimes() {
+		return org.mockito.Mockito.mock(TravelTimesForTrip.class);
+	}
+}

--- a/transitclock/src/test/java/org/transitclock/statistics/StatisticsTest.java
+++ b/transitclock/src/test/java/org/transitclock/statistics/StatisticsTest.java
@@ -1,0 +1,141 @@
+package org.transitclock.statistics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Test;
+
+public class StatisticsTest {
+
+	@Test
+	public void mean_ofSingleValueReturnsThatValue() {
+		assertThat(Statistics.mean(Collections.singletonList(42))).isEqualTo(42);
+	}
+
+	@Test
+	public void mean_ofMultipleValuesTruncates() {
+		// 10/3 = 3.333..., integer division truncates toward zero.
+		assertThat(Statistics.mean(Arrays.asList(3, 3, 4))).isEqualTo(3);
+	}
+
+	@Test
+	public void mean_doubleArrayReturnsExactAverage() {
+		assertThat(Statistics.mean(new double[] {1.0, 2.0, 3.0, 4.0}))
+				.isCloseTo(2.5, within(1e-9));
+	}
+
+	@Test
+	public void mean_doubleArrayEmptyIsNaN() {
+		assertThat(Statistics.mean(new double[0])).isNaN();
+	}
+
+	@Test
+	public void mean_intArrayReturnsDoubleAverage() {
+		assertThat(Statistics.mean(new int[] {1, 2, 3, 4}))
+				.isCloseTo(2.5, within(1e-9));
+	}
+
+	@Test
+	public void toArray_nullReturnsEmpty() {
+		assertThat(Statistics.toArray(null)).isEmpty();
+	}
+
+	@Test
+	public void toArray_convertsInOrder() {
+		assertThat(Statistics.toArray(Arrays.asList(5, 7, 9)))
+				.containsExactly(5, 7, 9);
+	}
+
+	@Test
+	public void toDoubleArray_fromIntArrayConverts() {
+		assertThat(Statistics.toDoubleArray(new int[] {1, 2, 3}))
+				.containsExactly(1.0, 2.0, 3.0);
+	}
+
+	@Test
+	public void toDoubleArray_fromNullListReturnsEmpty() {
+		assertThat(Statistics.toDoubleArray((List<Integer>) null)).isEmpty();
+	}
+
+	@Test
+	public void toDoubleArray_fromListConverts() {
+		assertThat(Statistics.toDoubleArray(Arrays.asList(4, 5)))
+				.containsExactly(4.0, 5.0);
+	}
+
+	@Test
+	public void getSampleStandardDeviation_matchesN_minus_1Formula() {
+		// values {2,4,4,4,5,5,7,9}, mean=5, sample stddev = sqrt(32/7) ~= 2.138.
+		double[] values = {2, 4, 4, 4, 5, 5, 7, 9};
+		double mean = Statistics.mean(values);
+		assertThat(mean).isCloseTo(5.0, within(1e-9));
+
+		double stdDev = Statistics.getSampleStandardDeviation(values, mean);
+		assertThat(stdDev).isCloseTo(Math.sqrt(32.0 / 7.0), within(1e-9));
+	}
+
+	@Test
+	public void getSampleStandardDeviation_singleValueIsNaN() {
+		// variance divides by N-1 == 0, so result is NaN.
+		double[] values = {10.0};
+		assertThat(Statistics.getSampleStandardDeviation(values, 10.0)).isNaN();
+	}
+
+	@Test
+	public void filteredMean_twoOrFewerValuesReturnsPlainMean() {
+		assertThat(Statistics.filteredMean(Arrays.asList(10, 1_000_000), 0.5))
+				.isEqualTo((10 + 1_000_000) / 2);
+	}
+
+	@Test
+	public void filteredMean_noOutliersReturnsUnfilteredMean() {
+		// All values within fractionalLimit of the mean, so nothing is filtered.
+		List<Integer> values = Arrays.asList(100, 110, 105, 95, 100);
+		assertThat(Statistics.filteredMean(values, 0.5))
+				.isEqualTo(Statistics.mean(values));
+	}
+
+	@Test
+	public void filteredMean_dropsWorstOutlier() {
+		// 1_000_000 is far above the 100-ish values; it should be removed.
+		List<Integer> values = Arrays.asList(100, 105, 110, 95, 1_000_000);
+		int withOutlier = Statistics.mean(values);
+		int filtered = Statistics.filteredMean(values, 0.7);
+
+		// Filtered mean should be close to the 100-ish cluster and well below
+		// the unfiltered mean which is dragged up by the outlier.
+		assertThat(filtered).isLessThan(withOutlier).isBetween(90, 120);
+	}
+
+	@Test
+	public void biasedFilteredMean_zeroBiasEqualsFilteredMean() {
+		List<Integer> values = Arrays.asList(100, 105, 110, 95, 1_000_000);
+		assertThat(Statistics.biasedFilteredMean(values, 0.7, 0.0))
+				.isEqualTo(Statistics.filteredMean(values, 0.7));
+	}
+
+	@Test
+	public void biasedFilteredMean_subtractsStandardDeviationTimesBias() {
+		// Use a dataset where nothing gets filtered so we can compute by hand.
+		List<Integer> values = Arrays.asList(10, 12, 14, 16, 18);
+		double[] doubles = Statistics.toDoubleArray(Statistics.toArray(values));
+		double mean = Statistics.mean(doubles);
+		double stdDev = Statistics.getSampleStandardDeviation(doubles, mean);
+
+		int biased = Statistics.biasedFilteredMean(values, 0.7, 1.0);
+
+		assertThat(biased).isEqualTo((int) Math.round(mean - stdDev));
+	}
+
+	@Test
+	public void biasedFilteredMean_withFewValuesFallsBackToMean() {
+		// Dataset collapses to ≤2 values after filtering → returns simple mean.
+		List<Integer> values = Arrays.asList(100, 120);
+		assertThat(Statistics.biasedFilteredMean(values, 0.5, 1.0))
+				.isEqualTo(Statistics.mean(values));
+	}
+}


### PR DESCRIPTION
## Summary
- Adds Mockito 5, AssertJ 3, upgrades JUnit to 4.13.2 (pins byte-buddy to resolve a Hibernate classpath conflict).
- Adds 20 new `transitclock` test classes covering pipeline, matching, prediction, headway/holding, and GTFS-ingest code.
- Test count: 339 → 477 (all passing locally on `mvn -pl transitclock test`).

## What's covered
**Tier 1 (pipeline):** `TravelTimes`, `SpatialMatcher`, `TemporalMatcher`, `PredictionGeneratorDefaultImpl`, `ArrivalDepartureGeneratorDefaultImpl`, `AvlProcessor`.
**Tier 2 (state + math):** `SpatialMatch`, core `VehicleState`, `ServiceUtils`, `BlockAssigner`, `RealTimeSchedAdhProcessor`.
**Tier 3 (generators):** scheduled + frequency `KalmanPredictionGeneratorImpl`, `HoldingTimeGeneratorDefaultImpl`, `LastDepartureHeadwayGenerator`, `LastArrivalsHeadwayGenerator`, `Statistics`.
**Tier 4 (GTFS ingest):** `TitleFormatter`, `StopPathProcessor`, `TravelTimesProcessorForGtfsUpdates`.

## Approach + trade-offs
- Low-coupling units (e.g. `TravelTimes`, `Statistics`, `TitleFormatter`, `ServiceUtils`, `BlockAssigner`, `SpatialMatch`) get thorough branch coverage.
- Orchestrators tightly bound to singletons (`AvlProcessor`, `ArrivalDepartureGeneratorDefaultImpl`, Kalman generators) get lightweight "contract + early-return" coverage — the deep paths require `Core` / `VehicleStateManager` / `DataDbLogger` singletons and belong in integration tests. Each test file documents this explicitly.
- Private pure-math helpers (e.g. `HoldingTimeGeneratorDefaultImpl.calculateHoldingTime`, headway generator statistics) are reached via reflection where they carry real algorithmic value.

## Test plan
- [x] `mvn -pl transitclock test` → 477 passing, 0 failures, 0 errors.
- [x] Each new test file runs clean in isolation via `mvn -pl transitclock test -Dtest=<ClassName>`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated test dependencies: JUnit → 4.13.2; added Mockito and AssertJ; pinned Byte Buddy.

* **Tests**
  * Added extensive unit tests across prediction, vehicle state, scheduling, matching, travel-times, headway/holding generators, GTFS processing, utilities, and a test-framework smoke test.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->