### PR TITLE
Pipeline behavior tests: predictions, arrivals/departures, matching, block assignment

### DIFF
--- a/transitclockPipelineTests/src/test/java/org/transitclock/pipelinetests/ArrivalDepartureBehaviorTest.java
+++ b/transitclockPipelineTests/src/test/java/org/transitclock/pipelinetests/ArrivalDepartureBehaviorTest.java
@@ -1,0 +1,199 @@
+package org.transitclock.pipelinetests;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Date;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.transitclock.core.AvlProcessor;
+import org.transitclock.core.VehicleState;
+import org.transitclock.core.dataCache.StopArrivalDepartureCacheFactory;
+import org.transitclock.core.dataCache.StopArrivalDepartureCacheKey;
+import org.transitclock.core.dataCache.VehicleStateManager;
+import org.transitclock.db.structs.AvlReport;
+import org.transitclock.db.structs.AvlReport.AssignmentType;
+import org.transitclock.ipc.data.IpcArrivalDeparture;
+
+/**
+ * Behavior tests for {@link org.transitclock.core.ArrivalDepartureGeneratorDefaultImpl}
+ * reached via {@code MatchProcessor.processArrivalDepartures}.
+ *
+ * <p>Drives a vehicle through two stops on block SE-08's first trip
+ * (868588900) and asserts that arrival/departure records show up in
+ * {@link org.transitclock.core.dataCache.StopArrivalDepartureCacheInterface}.
+ * The current pipeline suite only checks {@code isPredictable()} — a
+ * regression that breaks stop-traversal detection would leave the vehicle
+ * predictable but silently stop logging arrivals/departures, making this a
+ * distinct layer of coverage from {@link AvlProcessorBehaviorTest} and
+ * {@link PredictionGeneratorBehaviorTest}.
+ *
+ * <p>Trip 868588900 stop_times (verified via the 5A fixture):
+ * <pre>
+ *   stop_sequence 1:  14253 Dulles Airport         11:55:00
+ *   stop_sequence 4:  13056 Herndon-Monroe Park&amp;Ride 12:03:00
+ *   stop_sequence 6:  14078 N Moore + 19th         12:29:57
+ * </pre>
+ * The happy-path report anchors the vehicle at stop 14253 at 11:50; the
+ * advancement report places it at 13056 a few minutes after its scheduled
+ * arrival there.
+ */
+public class ArrivalDepartureBehaviorTest {
+
+	@ClassRule
+	public static final CoreHarness CORE = CoreHarness.withWmata5A();
+
+	private static final String BLOCK_ID = "SE-08";
+
+	// First stop of trip 868588900.
+	private static final String STOP_FIRST_ID = "14253";
+	private static final double STOP_FIRST_LAT = 38.953562;
+	private static final double STOP_FIRST_LON = -77.447485;
+
+	// A later stop on the same trip (stop_sequence 4).
+	private static final String STOP_ADVANCED_ID = "13056";
+	private static final double STOP_ADVANCED_LAT = 38.951704;
+	private static final double STOP_ADVANCED_LON = -77.383009;
+
+	/** 2016-06-20 11:50:00 America/New_York (EDT = UTC-4) → 15:50:00 UTC.
+	 *  Anchors the vehicle at the first stop 5 minutes before its scheduled
+	 *  departure, matching the known-good configuration of the happy-path
+	 *  test in {@link AvlProcessorBehaviorTest}. */
+	private static final long AVL_AT_FIRST_STOP_EPOCH_MS = 1466437800000L;
+
+	/** Keeps AVL timestamps strictly increasing across tests in this class. */
+	private static final AtomicLong nextTime = new AtomicLong(AVL_AT_FIRST_STOP_EPOCH_MS);
+
+	private static AvlReport avlReport(String vehicleId, double lat, double lon, long timeMs) {
+		return new AvlReport(vehicleId, timeMs, lat, lon,
+				Float.NaN, Float.NaN, "test");
+	}
+
+	/**
+	 * Pushes two AVL reports for {@code vehicleId}: one at the first stop of
+	 * trip 868588900, then one at the next timepoint ~8 minutes later. The
+	 * second report creates a previous-match / current-match pair with stops
+	 * traversed in between, which is the precondition for
+	 * ArrivalDepartureGenerator to actually produce records (without a
+	 * previous match and stopPathIndex=0 it short-circuits).
+	 *
+	 * @return the VehicleState after the second report was processed.
+	 */
+	private static VehicleState advanceVehicleFromFirstStopToNext(String vehicleId) {
+		// Step 1: report at the first stop — establishes the match but
+		// generates no arrival/departure records because there is no
+		// previous match and stopPathIndex is 0.
+		long t1 = nextTime.getAndAdd(1);
+		CORE.setNow(t1);
+		AvlReport first = avlReport(vehicleId, STOP_FIRST_LAT, STOP_FIRST_LON, t1);
+		first.setAssignment(BLOCK_ID, AssignmentType.BLOCK_ID);
+		AvlProcessor.getInstance().processAvlReport(first);
+
+		// Step 2: report at the advanced stop. Core's clock jumps forward so
+		// that travel-time-based extrapolation is plausible; the
+		// previous-match is the at-stop match from step 1.
+		long t2 = t1 + (8 * 60_000L); // 8 minutes later
+		nextTime.updateAndGet(cur -> Math.max(cur, t2 + 1));
+		CORE.setNow(t2);
+		AvlReport second = avlReport(vehicleId, STOP_ADVANCED_LAT, STOP_ADVANCED_LON, t2);
+		second.setAssignment(BLOCK_ID, AssignmentType.BLOCK_ID);
+		AvlProcessor.getInstance().processAvlReport(second);
+
+		return VehicleStateManager.getInstance().getVehicleState(vehicleId);
+	}
+
+	private static List<IpcArrivalDeparture> stopHistory(String stopId, long atEpochMs) {
+		StopArrivalDepartureCacheKey key = new StopArrivalDepartureCacheKey(stopId, new Date(atEpochMs));
+		List<IpcArrivalDeparture> events =
+				StopArrivalDepartureCacheFactory.getInstance().getStopHistory(key);
+		// Cache returns null for "no entries" (see ehcache StopArrivalDepartureCache).
+		// Normalize to an empty list so callers can use a uniform filter/assert pattern.
+		return events == null ? List.of() : events;
+	}
+
+	// ---------- Tests ----------
+
+	@Test
+	public void advancingVehicleRemainsPredictableWithNewerMatch() {
+		// Precondition for all other assertions in this class — if the second
+		// report doesn't match, no arrival/departure can be generated and the
+		// rest of the suite fails for a pre-check reason rather than a real
+		// regression. Run this first.
+		VehicleState state = advanceVehicleFromFirstStopToNext("v-ad-pre");
+		assertThat(state.isPredictable())
+				.as("vehicle should remain predictable after advancing to next stop")
+				.isTrue();
+		assertThat(state.getPreviousMatch())
+				.as("advancing produces a previous-match snapshot (required for AD generation)")
+				.isNotNull();
+	}
+
+	@Test
+	public void advancingVehicleLogsDepartureAtFirstStop() {
+		// When the vehicle was at stop 14253 and then moved away, the
+		// generator should emit a Departure at 14253 with isArrival=false.
+		VehicleState state = advanceVehicleFromFirstStopToNext("v-ad-depart");
+		long avlTime = state.getAvlReport().getTime();
+
+		List<IpcArrivalDeparture> history = stopHistory(STOP_FIRST_ID, avlTime);
+		assertThat(history)
+				.as("StopArrivalDepartureCache should have at least one record for stop %s", STOP_FIRST_ID)
+				.isNotEmpty();
+
+		boolean hasDeparture = history.stream()
+				.filter(e -> "v-ad-depart".equals(e.getVehicleId()))
+				.anyMatch(e -> !e.isArrival());
+		assertThat(hasDeparture)
+				.as("a departure record for vehicle v-ad-depart at stop %s should exist", STOP_FIRST_ID)
+				.isTrue();
+	}
+
+	@Test
+	public void advancingVehicleLogsArrivalAtNextStop() {
+		// Counterpart to the departure test: when the vehicle arrives at
+		// 13056, the generator should emit an Arrival there.
+		VehicleState state = advanceVehicleFromFirstStopToNext("v-ad-arrive");
+		long avlTime = state.getAvlReport().getTime();
+
+		List<IpcArrivalDeparture> history = stopHistory(STOP_ADVANCED_ID, avlTime);
+		assertThat(history)
+				.as("StopArrivalDepartureCache should have at least one record for stop %s", STOP_ADVANCED_ID)
+				.isNotEmpty();
+
+		boolean hasArrival = history.stream()
+				.filter(e -> "v-ad-arrive".equals(e.getVehicleId()))
+				.anyMatch(IpcArrivalDeparture::isArrival);
+		assertThat(hasArrival)
+				.as("an arrival record for vehicle v-ad-arrive at stop %s should exist", STOP_ADVANCED_ID)
+				.isTrue();
+	}
+
+	@Test
+	public void generatedRecordsCarryCorrectBlockAndTripMetadata() {
+		// Pull any record generated for our vehicle out of the first stop's
+		// cache and assert its block/trip/stop fields line up with what we
+		// assigned. Defends against a silent regression that swaps
+		// identifying fields during IpcArrivalDeparture marshalling.
+		//
+		// NOTE: IpcArrivalDeparture marks routeId, routeShortName, and
+		// serviceId as `transient`, so they are null after the Kyro
+		// serializer round-trips through ehcache. Assertions therefore only
+		// cover fields that survive serialization.
+		VehicleState state = advanceVehicleFromFirstStopToNext("v-ad-meta");
+		long avlTime = state.getAvlReport().getTime();
+
+		List<IpcArrivalDeparture> history = stopHistory(STOP_FIRST_ID, avlTime);
+		IpcArrivalDeparture mine = history.stream()
+				.filter(e -> "v-ad-meta".equals(e.getVehicleId()))
+				.findFirst()
+				.orElseThrow(() -> new AssertionError(
+						"no arrival/departure recorded for v-ad-meta at stop " + STOP_FIRST_ID));
+
+		assertThat(mine.getBlockId()).isEqualTo(BLOCK_ID);
+		assertThat(mine.getStopId()).isEqualTo(STOP_FIRST_ID);
+		assertThat(mine.getTripId()).isEqualTo("868588900");
+		assertThat(mine.getDirectionId()).isEqualTo("0");
+	}
+}

--- a/transitclockPipelineTests/src/test/java/org/transitclock/pipelinetests/BlockAssignerBehaviorTest.java
+++ b/transitclockPipelineTests/src/test/java/org/transitclock/pipelinetests/BlockAssignerBehaviorTest.java
@@ -1,0 +1,167 @@
+package org.transitclock.pipelinetests;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.transitclock.core.BlockAssigner;
+import org.transitclock.db.structs.AvlReport;
+import org.transitclock.db.structs.AvlReport.AssignmentType;
+import org.transitclock.db.structs.Block;
+
+/**
+ * Behavior tests for {@link BlockAssigner} against a real
+ * {@link org.transitclock.gtfs.DbConfig} loaded from the WMATA 5A fixture.
+ *
+ * <p>BlockAssigner is 180 lines but touches every AVL report flowing through
+ * AvlProcessor. A regression here would cause silent mass-unassignment of
+ * vehicles — each vehicle becomes {@code !isPredictable} because its block
+ * can't be resolved, so AvlProcessorBehaviorTest would still pass the
+ * "match at first stop" case while everything in production reports
+ * unpredictable. These tests exercise the three non-trivial lookup paths
+ * (BLOCK_ID, TRIP_ID, TRIP_SHORT_NAME) plus the negative cases.
+ *
+ * <p>The 5A fixture has no {@code trip_short_name} column in {@code trips.txt},
+ * so {@link org.transitclock.gtfs.gtfsStructs.GtfsTrip} falls back to using
+ * {@code trip_id} as the short name. Hence a TRIP_SHORT_NAME assignment with
+ * "868588900" resolves via the same underlying trip as a TRIP_ID assignment
+ * with "868588900".
+ */
+public class BlockAssignerBehaviorTest {
+
+	@ClassRule
+	public static final CoreHarness CORE = CoreHarness.withWmata5A();
+
+	private static final String KNOWN_BLOCK_ID = "SE-08";
+	private static final String KNOWN_TRIP_ID = "868588900";
+	private static final String KNOWN_ROUTE_ID = "5A";
+
+	/** 2016-06-20 11:50:00 America/New_York — same anchor the other behavior
+	 *  tests use to ensure the relevant service IDs are active. */
+	private static final long ASSIGNMENT_TEST_EPOCH_MS = 1466437800000L;
+
+	private static AvlReport avlWithAssignment(
+			String vehicleId, String assignmentId, AssignmentType type) {
+		AvlReport report = new AvlReport(vehicleId,
+				ASSIGNMENT_TEST_EPOCH_MS,
+				38.953562, -77.447485,
+				Float.NaN, Float.NaN, "test");
+		if (assignmentId != null) {
+			report.setAssignment(assignmentId, type);
+		}
+		return report;
+	}
+
+	// ---------- Tests ----------
+
+	@Test
+	public void blockIdAssignmentResolvesToKnownBlock() {
+		CORE.setNow(ASSIGNMENT_TEST_EPOCH_MS);
+		AvlReport report = avlWithAssignment("v-bid", KNOWN_BLOCK_ID, AssignmentType.BLOCK_ID);
+
+		Block block = BlockAssigner.getInstance().getBlockAssignment(report);
+
+		assertThat(block)
+				.as("BLOCK_ID assignment %s should resolve to a non-null Block on an active service day",
+						KNOWN_BLOCK_ID)
+				.isNotNull();
+		assertThat(block.getId()).isEqualTo(KNOWN_BLOCK_ID);
+	}
+
+	@Test
+	public void tripIdAssignmentResolvesToContainingBlock() {
+		CORE.setNow(ASSIGNMENT_TEST_EPOCH_MS);
+		AvlReport report = avlWithAssignment("v-tid", KNOWN_TRIP_ID, AssignmentType.TRIP_ID);
+
+		Block block = BlockAssigner.getInstance().getBlockAssignment(report);
+
+		assertThat(block)
+				.as("TRIP_ID assignment should resolve to the trip's containing block")
+				.isNotNull();
+		// Trip 868588900 belongs to block SE-08 per trips.txt.
+		assertThat(block.getId()).isEqualTo(KNOWN_BLOCK_ID);
+	}
+
+	@Test
+	public void tripShortNameAssignmentResolvesToContainingBlock() {
+		// In the 5A fixture trip_short_name falls back to trip_id because
+		// the trips.txt has no trip_short_name column. So "868588900" is
+		// a valid trip short name here.
+		CORE.setNow(ASSIGNMENT_TEST_EPOCH_MS);
+		AvlReport report = avlWithAssignment("v-tsn", KNOWN_TRIP_ID, AssignmentType.TRIP_SHORT_NAME);
+
+		Block block = BlockAssigner.getInstance().getBlockAssignment(report);
+
+		assertThat(block)
+				.as("TRIP_SHORT_NAME assignment should resolve to the trip's block via short-name lookup")
+				.isNotNull();
+		assertThat(block.getId()).isEqualTo(KNOWN_BLOCK_ID);
+	}
+
+	@Test
+	public void routeIdAssignmentDoesNotResolveToBlock() {
+		// ROUTE_ID is not a block assignment — BlockAssigner.getBlockAssignment
+		// must return null for it. If this ever changes, vehicles assigned to
+		// a route would unexpectedly be matched to a block, changing the
+		// prediction semantics.
+		CORE.setNow(ASSIGNMENT_TEST_EPOCH_MS);
+		AvlReport report = avlWithAssignment("v-rid", KNOWN_ROUTE_ID, AssignmentType.ROUTE_ID);
+
+		Block block = BlockAssigner.getInstance().getBlockAssignment(report);
+
+		assertThat(block)
+				.as("ROUTE_ID assignments should never produce a block")
+				.isNull();
+	}
+
+	@Test
+	public void unassignedReportProducesNoBlock() {
+		AvlReport report = avlWithAssignment("v-unset", null, AssignmentType.UNSET);
+
+		Block block = BlockAssigner.getInstance().getBlockAssignment(report);
+
+		assertThat(block)
+				.as("AVL reports with no assignment should not produce a block")
+				.isNull();
+	}
+
+	@Test
+	public void invalidBlockIdProducesNoBlock() {
+		CORE.setNow(ASSIGNMENT_TEST_EPOCH_MS);
+		AvlReport report = avlWithAssignment("v-bad-bid", "DOES-NOT-EXIST", AssignmentType.BLOCK_ID);
+
+		Block block = BlockAssigner.getInstance().getBlockAssignment(report);
+
+		assertThat(block)
+				.as("nonsense BLOCK_ID should return null rather than throwing")
+				.isNull();
+	}
+
+	@Test
+	public void invalidTripIdProducesNoBlock() {
+		CORE.setNow(ASSIGNMENT_TEST_EPOCH_MS);
+		AvlReport report = avlWithAssignment("v-bad-tid", "DOES-NOT-EXIST", AssignmentType.TRIP_ID);
+
+		Block block = BlockAssigner.getInstance().getBlockAssignment(report);
+
+		assertThat(block)
+				.as("nonsense TRIP_ID should return null rather than throwing")
+				.isNull();
+	}
+
+	@Test
+	public void getRouteIdAssignmentReturnsIdOnlyForRouteIdType() {
+		// Exercises the second public entry point. The BLOCK_ID variant
+		// should not accidentally return the block id as if it were a
+		// route id.
+		AvlReport asRoute = avlWithAssignment("v-ret-route", KNOWN_ROUTE_ID, AssignmentType.ROUTE_ID);
+		AvlReport asBlock = avlWithAssignment("v-ret-block", KNOWN_BLOCK_ID, AssignmentType.BLOCK_ID);
+
+		assertThat(BlockAssigner.getInstance().getRouteIdAssignment(asRoute))
+				.as("ROUTE_ID assignment should surface the id")
+				.isEqualTo(KNOWN_ROUTE_ID);
+		assertThat(BlockAssigner.getInstance().getRouteIdAssignment(asBlock))
+				.as("BLOCK_ID assignment should not be misreported as a route id")
+				.isNull();
+	}
+}

--- a/transitclockPipelineTests/src/test/java/org/transitclock/pipelinetests/MatchingBehaviorTest.java
+++ b/transitclockPipelineTests/src/test/java/org/transitclock/pipelinetests/MatchingBehaviorTest.java
@@ -1,0 +1,171 @@
+package org.transitclock.pipelinetests;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.transitclock.configData.CoreConfig;
+import org.transitclock.core.AvlProcessor;
+import org.transitclock.core.TemporalMatch;
+import org.transitclock.core.VehicleAtStopInfo;
+import org.transitclock.core.VehicleState;
+import org.transitclock.core.dataCache.VehicleStateManager;
+import org.transitclock.db.structs.AvlReport;
+import org.transitclock.db.structs.AvlReport.AssignmentType;
+import org.transitclock.utils.Geo;
+
+/**
+ * Behavior tests for the spatial + temporal matching stack
+ * ({@link org.transitclock.core.SpatialMatcher} /
+ * {@link org.transitclock.core.TemporalMatcher}) as observed through the
+ * {@link TemporalMatch} that AvlProcessor stashes on each
+ * {@link VehicleState}.
+ *
+ * <p>{@link AvlProcessorBehaviorTest} asserts "vehicle is predictable" — a
+ * coarse signal. A regression where the matcher snaps to the wrong segment,
+ * picks the wrong trip, or silently loses adherence information could leave
+ * that check green while breaking predictions for real users. These tests
+ * inspect the match itself: the stop path index, the distance-to-segment, the
+ * at-stop indicator, the trip/block reference, and the adherence value.
+ */
+public class MatchingBehaviorTest {
+
+	@ClassRule
+	public static final CoreHarness CORE = CoreHarness.withWmata5A();
+
+	private static final String BLOCK_ID = "SE-08";
+	private static final String TRIP_ID = "868588900";
+
+	private static final String FIRST_STOP_ID = "14253";
+	private static final double FIRST_STOP_LAT = 38.953562;
+	private static final double FIRST_STOP_LON = -77.447485;
+
+	/** 2016-06-20 11:50:00 America/New_York (EDT = UTC-4) → 15:50:00 UTC. */
+	private static final long HAPPY_PATH_EPOCH_MS = 1466437800000L;
+
+	/** Keeps AVL timestamps strictly increasing across tests in this class. */
+	private static final AtomicLong nextTime = new AtomicLong(HAPPY_PATH_EPOCH_MS);
+
+	private static AvlReport avlReport(String vehicleId, double lat, double lon, long timeMs) {
+		return new AvlReport(vehicleId, timeMs, lat, lon,
+				Float.NaN, Float.NaN, "test");
+	}
+
+	private static VehicleState matchAtFirstStop(String vehicleId) {
+		long t = nextTime.getAndIncrement();
+		CORE.setNow(t);
+		AvlReport report = avlReport(vehicleId, FIRST_STOP_LAT, FIRST_STOP_LON, t);
+		report.setAssignment(BLOCK_ID, AssignmentType.BLOCK_ID);
+		AvlProcessor.getInstance().processAvlReport(report);
+		return VehicleStateManager.getInstance().getVehicleState(vehicleId);
+	}
+
+	// ---------- Tests ----------
+
+	@Test
+	public void matchAtFirstStopReportsAtStopIndicator() {
+		// A vehicle reporting exactly at the first stop's published lat/lon
+		// should be marked as at-stop — SpatialMatcher uses a tolerance on
+		// the distance along the path to decide this. Regression: if the
+		// at-stop threshold drifts, predictions would stop treating a vehicle
+		// as "at" the stop and would begin predicting future arrivals while
+		// the vehicle is still parked there.
+		VehicleState state = matchAtFirstStop("v-match-atstop");
+		TemporalMatch match = state.getMatch();
+
+		assertThat(match).as("happy-path match is a prerequisite").isNotNull();
+		assertThat(match.isAtStop())
+				.as("vehicle at the first stop's coordinates should be marked at-stop")
+				.isTrue();
+
+		VehicleAtStopInfo atStop = match.getAtStop();
+		assertThat(atStop)
+				.as("getAtStop() should expose the at-stop indices when isAtStop() is true")
+				.isNotNull();
+		assertThat(atStop.getStopId()).isEqualTo(FIRST_STOP_ID);
+	}
+
+	@Test
+	public void matchStopPathIndexIsZeroAtBeginningOfTrip() {
+		// First stop of the trip → stopPathIndex 0. Off-by-one regressions
+		// in trip iteration would surface as wrong predictions for the
+		// next stop (i.e. skipping the first stop altogether).
+		VehicleState state = matchAtFirstStop("v-match-spi0");
+		TemporalMatch match = state.getMatch();
+
+		assertThat(match).isNotNull();
+		assertThat(match.getStopPathIndex())
+				.as("first stop of a trip has stopPathIndex 0")
+				.isEqualTo(0);
+	}
+
+	@Test
+	public void matchCarriesTripAndBlockReferences() {
+		// The match's trip and block references are used by every downstream
+		// stage (prediction, arrival/departure, holding). If these are null
+		// the vehicle is formally predictable but nothing else works —
+		// exactly the kind of bug a binary isPredictable() check misses.
+		VehicleState state = matchAtFirstStop("v-match-refs");
+		TemporalMatch match = state.getMatch();
+
+		assertThat(match).isNotNull();
+		assertThat(match.getTrip()).isNotNull();
+		assertThat(match.getTrip().getId()).isEqualTo(TRIP_ID);
+		assertThat(match.getBlock()).isNotNull();
+		assertThat(match.getBlock().getId()).isEqualTo(BLOCK_ID);
+		assertThat(match.getRoute()).isNotNull();
+		assertThat(match.getRoute().getId()).isEqualTo("5A");
+	}
+
+	@Test
+	public void matchDistanceIsWithinMaxDistanceFromSegmentConfig() {
+		// Sanity: when we drop a vehicle exactly on the published stop
+		// location, the distance-to-segment should be well under the
+		// configured threshold. A large distance here would indicate the
+		// matcher picked the wrong segment or the projection math is off.
+		VehicleState state = matchAtFirstStop("v-match-dist");
+		TemporalMatch match = state.getMatch();
+
+		assertThat(match).isNotNull();
+		double maxDist = CoreConfig.getMaxDistanceFromSegment();
+		assertThat(match.getDistanceToSegment())
+				.as("match distance should be <= configured maxDistanceFromSegment (%s m)", maxDist)
+				.isLessThanOrEqualTo(maxDist);
+	}
+
+	@Test
+	public void vehicleStateCarriesScheduleAdherenceAfterMatch() {
+		// TemporalMatcher populates real-time schedule adherence on the
+		// vehicle state. A missing adherence value means the UI can't show
+		// "on time" / "late" indicators and API consumers that filter on
+		// adherence would see incorrect results.
+		VehicleState state = matchAtFirstStop("v-match-adh");
+
+		assertThat(state.getRealTimeSchedAdh())
+				.as("matched vehicle should have a non-null real-time schedule adherence")
+				.isNotNull();
+	}
+
+	@Test
+	public void matchLocationProjectsCloseToReportedLocation() {
+		// The matcher projects the AVL location onto the nearest path
+		// segment. The projected location should be close to where the
+		// vehicle actually reported — "close" meaning within the
+		// configured max-distance-from-segment, since anything farther
+		// wouldn't have been accepted as a match in the first place.
+		VehicleState state = matchAtFirstStop("v-match-proj");
+		TemporalMatch match = state.getMatch();
+
+		assertThat(match).isNotNull();
+		assertThat(match.getLocation()).isNotNull();
+
+		double distance = Geo.distance(match.getLocation(),
+				state.getAvlReport().getLocation());
+		double maxDist = CoreConfig.getMaxDistanceFromSegment();
+		assertThat(distance)
+				.as("projected match location should be within matcher tolerance of the AVL point")
+				.isLessThanOrEqualTo(maxDist);
+	}
+}

--- a/transitclockPipelineTests/src/test/java/org/transitclock/pipelinetests/PredictionGeneratorBehaviorTest.java
+++ b/transitclockPipelineTests/src/test/java/org/transitclock/pipelinetests/PredictionGeneratorBehaviorTest.java
@@ -124,9 +124,10 @@ public class PredictionGeneratorBehaviorTest {
 		// Every prediction should be at or after the AVL report time. A
 		// prediction in the past would mean PredictionGenerator produced a
 		// stale ETA, which is a user-visible defect (UI would show "arriving"
-		// forever).
+		// forever). isNotEmpty() guards against an empty-list vacuous pass.
 		assertThat(state.getPredictions())
 				.as("predictions should not be in the past relative to the AVL report")
+				.isNotEmpty()
 				.allSatisfy(p -> assertThat(p.getPredictionTime())
 						.isGreaterThanOrEqualTo(avlTime));
 	}
@@ -142,12 +143,15 @@ public class PredictionGeneratorBehaviorTest {
 		// block SE-08.
 		assertThat(state.getPredictions())
 				.as("all predictions must come from the assigned block")
+				.isNotEmpty()
 				.allSatisfy(p -> assertThat(p.getBlockId()).isEqualTo(BLOCK_ID));
 		assertThat(state.getPredictions())
 				.as("all predictions must carry our route's short name")
+				.isNotEmpty()
 				.allSatisfy(p -> assertThat(p.getRouteShortName()).isEqualTo(ROUTE_SHORT_NAME));
 		// The vehicle id is copied onto each prediction for downstream IPC.
 		assertThat(state.getPredictions())
+				.isNotEmpty()
 				.allSatisfy(p -> assertThat(p.getVehicleId()).isEqualTo("v-preds-meta"));
 	}
 
@@ -175,14 +179,20 @@ public class PredictionGeneratorBehaviorTest {
 	}
 
 	@Test
-	public void bothArrivalAndDeparturePredictionsArePresentForMidTripStops() {
+	public void bothArrivalAndDeparturePredictionsArePresentOnActiveTrip() {
 		pushHappyPathReport("v-preds-arrdep");
 
 		VehicleState state = VehicleStateManager.getInstance().getVehicleState("v-preds-arrdep");
-		// PredictionGenerator emits both an arrival and a departure prediction
-		// for each non-terminal stop. Missing one type would mean the UI
+		// PredictionGenerator emits an arrival prediction for stops the
+		// vehicle will arrive at, and a departure prediction at stops where
+		// there's a scheduled dwell (notably the first stop of the trip).
+		// Missing either variant on the entire active trip would mean the UI
 		// shows only "arriving" but not "departing" (or vice versa) — a
-		// silent capability regression rather than a crash.
+		// silent capability regression rather than a crash. We assert at
+		// trip scope rather than per-stop because the per-stop emission
+		// mix depends on which stops have scheduled departure times in
+		// the GTFS, which is a different invariant than this test is
+		// checking.
 		boolean anyArrival = state.getPredictions().stream()
 				.filter(p -> TRIP_ID.equals(p.getTripId()))
 				.anyMatch(IpcPrediction::isArrival);

--- a/transitclockPipelineTests/src/test/java/org/transitclock/pipelinetests/PredictionGeneratorBehaviorTest.java
+++ b/transitclockPipelineTests/src/test/java/org/transitclock/pipelinetests/PredictionGeneratorBehaviorTest.java
@@ -1,0 +1,199 @@
+package org.transitclock.pipelinetests;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.transitclock.core.AvlProcessor;
+import org.transitclock.core.VehicleState;
+import org.transitclock.core.dataCache.PredictionDataCache;
+import org.transitclock.core.dataCache.VehicleStateManager;
+import org.transitclock.db.structs.AvlReport;
+import org.transitclock.db.structs.AvlReport.AssignmentType;
+import org.transitclock.ipc.data.IpcPrediction;
+import org.transitclock.ipc.data.IpcPredictionsForRouteStopDest;
+
+/**
+ * Behavior tests for {@link org.transitclock.core.PredictionGeneratorDefaultImpl}
+ * (reached via {@code MatchProcessor.processPredictions}). These tests verify
+ * that a successful AVL match produces predictions with plausible content —
+ * {@link AvlProcessorBehaviorTest} only checks that the vehicle becomes
+ * {@code isPredictable()}; it never inspects the generated predictions.
+ *
+ * <p>Reuses the same happy-path fixture as {@link AvlProcessorBehaviorTest}:
+ * block SE-08, trip 868588900, first stop 14253 at 2016-06-20 11:50 EDT.
+ * If the happy-path test fails, these will too — fix that one first.
+ */
+public class PredictionGeneratorBehaviorTest {
+
+	@ClassRule
+	public static final CoreHarness CORE = CoreHarness.withWmata5A();
+
+	private static final String ROUTE_SHORT_NAME = "5A";
+	private static final String BLOCK_ID = "SE-08";
+	private static final String TRIP_ID = "868588900";
+
+	private static final double FIRST_STOP_LAT = 38.953562;
+	private static final double FIRST_STOP_LON = -77.447485;
+
+	/**
+	 * Scheduled departure of trip 868588900 from first stop 14253:
+	 * 11:55:00 America/New_York on 2016-06-20 → 15:55:00 UTC.
+	 * Pin the clock 5 minutes before that so the vehicle is in a
+	 * sensible "pre-departure" posture when it reports.
+	 */
+	private static final long HAPPY_PATH_EPOCH_MS = 1466437800000L;
+
+	/**
+	 * Stop IDs on trip 868588900 in sequence order (per
+	 * {@code transitclockIntegration/src/test/resources/gtfs/5A/stop_times.txt}):
+	 * 14253 (11:55), 13056 (12:03), 14078 (12:30), 15241 (12:42:50), 17201 (12:43).
+	 *
+	 * <p>PredictionGenerator's default horizon is 45 minutes from the AVL
+	 * timestamp (see {@code transitclock.core.maxPredictionsTimeSecs}), so
+	 * 15241 and 17201 fall outside the horizon for an 11:50 AVL report and
+	 * intentionally receive no predictions. Tests only assert on the
+	 * in-horizon stops.
+	 */
+	private static final String STOP_FIRST = "14253";
+	private static final String STOP_MID = "14078";
+
+	/** Keeps the AVL timestamp strictly increasing across tests in this class. */
+	private static final AtomicLong nextTime = new AtomicLong(HAPPY_PATH_EPOCH_MS);
+
+	private static AvlReport avlReport(String vehicleId, double lat, double lon, long timeMs) {
+		return new AvlReport(vehicleId, timeMs, lat, lon,
+				Float.NaN, Float.NaN, "test");
+	}
+
+	private static void pushHappyPathReport(String vehicleId) {
+		long t = nextTime.getAndIncrement();
+		CORE.setNow(t);
+		AvlReport report = avlReport(vehicleId, FIRST_STOP_LAT, FIRST_STOP_LON, t);
+		report.setAssignment(BLOCK_ID, AssignmentType.BLOCK_ID);
+		AvlProcessor.getInstance().processAvlReport(report);
+	}
+
+	private static List<IpcPrediction> predictionsForVehicleAtStop(
+			String vehicleId, String stopId) {
+		List<IpcPredictionsForRouteStopDest> forStop =
+				PredictionDataCache.getInstance().getPredictions(
+						ROUTE_SHORT_NAME, null, stopId);
+		return forStop.stream()
+				.flatMap(p -> p.getPredictionsForRouteStop().stream())
+				.filter(p -> vehicleId.equals(p.getVehicleId()))
+				.toList();
+	}
+
+	// ---------- Tests ----------
+
+	@Test
+	public void happyPathMatchPopulatesVehicleStatePredictions() {
+		pushHappyPathReport("v-preds-vs");
+
+		VehicleState state = VehicleStateManager.getInstance().getVehicleState("v-preds-vs");
+		assertThat(state.isPredictable())
+				.as("pre-req: vehicle must match before predictions are expected")
+				.isTrue();
+		assertThat(state.getPredictions())
+				.as("matched vehicle should have a non-empty predictions list on its state")
+				.isNotNull()
+				.isNotEmpty();
+	}
+
+	@Test
+	public void happyPathMatchPopulatesPredictionDataCacheForFirstStop() {
+		pushHappyPathReport("v-preds-cache-first");
+
+		List<IpcPrediction> preds = predictionsForVehicleAtStop("v-preds-cache-first", STOP_FIRST);
+		assertThat(preds)
+				.as("PredictionDataCache should have at least one prediction for the vehicle at its first stop")
+				.isNotEmpty();
+	}
+
+	@Test
+	public void predictionTimesAreInTheFutureRelativeToAvlClock() {
+		pushHappyPathReport("v-preds-future");
+
+		VehicleState state = VehicleStateManager.getInstance().getVehicleState("v-preds-future");
+		long avlTime = state.getAvlReport().getTime();
+
+		// Every prediction should be at or after the AVL report time. A
+		// prediction in the past would mean PredictionGenerator produced a
+		// stale ETA, which is a user-visible defect (UI would show "arriving"
+		// forever).
+		assertThat(state.getPredictions())
+				.as("predictions should not be in the past relative to the AVL report")
+				.allSatisfy(p -> assertThat(p.getPredictionTime())
+						.isGreaterThanOrEqualTo(avlTime));
+	}
+
+	@Test
+	public void predictionsCarryExpectedTripAndRouteMetadata() {
+		pushHappyPathReport("v-preds-meta");
+
+		VehicleState state = VehicleStateManager.getInstance().getVehicleState("v-preds-meta");
+		// All predictions for this vehicle belong to the block we assigned;
+		// the vehicle hasn't progressed to the next block's trips yet, so
+		// every prediction should carry trip 868588900 or a later trip in
+		// block SE-08.
+		assertThat(state.getPredictions())
+				.as("all predictions must come from the assigned block")
+				.allSatisfy(p -> assertThat(p.getBlockId()).isEqualTo(BLOCK_ID));
+		assertThat(state.getPredictions())
+				.as("all predictions must carry our route's short name")
+				.allSatisfy(p -> assertThat(p.getRouteShortName()).isEqualTo(ROUTE_SHORT_NAME));
+		// The vehicle id is copied onto each prediction for downstream IPC.
+		assertThat(state.getPredictions())
+				.allSatisfy(p -> assertThat(p.getVehicleId()).isEqualTo("v-preds-meta"));
+	}
+
+	@Test
+	public void predictionsCoverInHorizonStopsOfCurrentTrip() {
+		pushHappyPathReport("v-preds-coverage");
+
+		VehicleState state = VehicleStateManager.getInstance().getVehicleState("v-preds-coverage");
+		// Trip 868588900 has 5 scheduled stops; only the first three
+		// (14253, 13056, 14078) fall inside the 45-minute prediction
+		// horizon from an 11:50 EDT AVL report. Assert we got at least
+		// the first and a mid-trip stop — this catches an off-by-one in
+		// stop iteration that would drop the middle of the trip while
+		// still emitting something for the first stop (the shape of a
+		// subtle regression that a pure "is the list non-empty" check
+		// would miss).
+		List<String> currentTripStopIds = state.getPredictions().stream()
+				.filter(p -> TRIP_ID.equals(p.getTripId()))
+				.map(IpcPrediction::getStopId)
+				.distinct()
+				.toList();
+		assertThat(currentTripStopIds)
+				.as("predictions for trip %s should cover first and mid-trip stops", TRIP_ID)
+				.contains(STOP_FIRST, STOP_MID);
+	}
+
+	@Test
+	public void bothArrivalAndDeparturePredictionsArePresentForMidTripStops() {
+		pushHappyPathReport("v-preds-arrdep");
+
+		VehicleState state = VehicleStateManager.getInstance().getVehicleState("v-preds-arrdep");
+		// PredictionGenerator emits both an arrival and a departure prediction
+		// for each non-terminal stop. Missing one type would mean the UI
+		// shows only "arriving" but not "departing" (or vice versa) — a
+		// silent capability regression rather than a crash.
+		boolean anyArrival = state.getPredictions().stream()
+				.filter(p -> TRIP_ID.equals(p.getTripId()))
+				.anyMatch(IpcPrediction::isArrival);
+		boolean anyDeparture = state.getPredictions().stream()
+				.filter(p -> TRIP_ID.equals(p.getTripId()))
+				.anyMatch(p -> !p.isArrival());
+		assertThat(anyArrival)
+				.as("at least one prediction for the active trip should be an arrival")
+				.isTrue();
+		assertThat(anyDeparture)
+				.as("at least one prediction for the active trip should be a departure")
+				.isTrue();
+	}
+}

--- a/transitclockPipelineTests/src/test/resources/ehcache.xml
+++ b/transitclockPipelineTests/src/test/resources/ehcache.xml
@@ -38,7 +38,9 @@
 		</ehcache:expiry>
 		<ehcache:resources>
 			<ehcache:heap unit="entries">63000</ehcache:heap>
-			<ehcache:disk persistent="true" unit="GB">5</ehcache:disk>
+			<!-- Not persistent in tests: hermetic runs shouldn't read cache
+			     state carried over from a previous invocation. -->
+			<ehcache:disk unit="GB">5</ehcache:disk>
 		</ehcache:resources>
 		<ehcache:disk-store-settings thread-pool="pool-disk"
 			writer-concurrency="1" />
@@ -52,7 +54,7 @@
 		</ehcache:expiry>
 		<ehcache:resources>
 			<ehcache:heap unit="entries">15000</ehcache:heap>
-			<ehcache:disk persistent="true" unit="GB">10</ehcache:disk>
+			<ehcache:disk unit="GB">10</ehcache:disk>
 		</ehcache:resources>
 		<ehcache:disk-store-settings thread-pool="pool-disk"
 			writer-concurrency="1" />
@@ -66,7 +68,7 @@
 		</ehcache:expiry>
 		<ehcache:resources>
 			<ehcache:heap unit="entries">100000</ehcache:heap>
-			<ehcache:disk persistent="true" unit="GB">1</ehcache:disk>
+			<ehcache:disk unit="GB">1</ehcache:disk>
 		</ehcache:resources>
 	</ehcache:cache>
 

--- a/transitclockPipelineTests/src/test/resources/ehcache.xml
+++ b/transitclockPipelineTests/src/test/resources/ehcache.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+	Pipeline-test-only ehcache configuration.
+	Shadows the copy in transitclockCore (src/main/resources/ehcache.xml)
+	which hardcodes a persistence directory of /usr/local/transitclock/cache/ —
+	not writable under CI or most dev machines. This file uses a path under
+	the module's own target/ directory so it is fresh-per-build and always
+	writable. Keep the cache aliases and shapes in sync with the main file;
+	only the persistence directory differs.
+-->
+<ehcache:config xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'
+	xmlns:ehcache='http://www.ehcache.org/v3'
+	xsi:schemaLocation="http://www.ehcache.org/v3 http://www.ehcache.org/schema/ehcache-core-3.1.xsd">
+	<ehcache:persistence directory="target/ehcache-pipeline-store" />
+	<ehcache:disk-store thread-pool="pool-disk" />
+
+
+	<ehcache:cache alias="dwellTimeModelCache">
+		<ehcache:key-type>org.transitclock.core.dataCache.StopPathCacheKey</ehcache:key-type>
+		<ehcache:value-type>org.transitclock.core.predictiongenerator.scheduled.dwell.DwellModel</ehcache:value-type>
+		<ehcache:expiry>
+			<ehcache:tti unit="days">7</ehcache:tti>
+		</ehcache:expiry>
+		<ehcache:resources>
+			<ehcache:heap unit="entries">2000</ehcache:heap>
+			<ehcache:disk unit="MB">200</ehcache:disk>
+		</ehcache:resources>
+		<ehcache:disk-store-settings thread-pool="pool-disk"
+			writer-concurrency="1" />
+	</ehcache:cache>
+
+	<ehcache:cache alias="arrivalDeparturesByTrip">
+		<ehcache:key-type>org.transitclock.core.dataCache.TripKey</ehcache:key-type>
+		<ehcache:value-type serializer="org.transitclock.core.dataCache.ehcache.serializers.TripEventsKyroSerializer">org.transitclock.core.dataCache.TripEvents</ehcache:value-type>
+		<ehcache:expiry>
+			<ehcache:tti unit="days">7</ehcache:tti>
+		</ehcache:expiry>
+		<ehcache:resources>
+			<ehcache:heap unit="entries">63000</ehcache:heap>
+			<ehcache:disk persistent="true" unit="GB">5</ehcache:disk>
+		</ehcache:resources>
+		<ehcache:disk-store-settings thread-pool="pool-disk"
+			writer-concurrency="1" />
+	</ehcache:cache>
+
+	<ehcache:cache alias="arrivalDeparturesByStop">
+		<ehcache:key-type>org.transitclock.core.dataCache.StopArrivalDepartureCacheKey</ehcache:key-type>
+		<ehcache:value-type serializer="org.transitclock.core.dataCache.ehcache.serializers.StopEventsKyroSerializer">org.transitclock.core.dataCache.StopEvents</ehcache:value-type>
+		<ehcache:expiry>
+			<ehcache:ttl unit="days">1</ehcache:ttl>
+		</ehcache:expiry>
+		<ehcache:resources>
+			<ehcache:heap unit="entries">15000</ehcache:heap>
+			<ehcache:disk persistent="true" unit="GB">10</ehcache:disk>
+		</ehcache:resources>
+		<ehcache:disk-store-settings thread-pool="pool-disk"
+			writer-concurrency="1" />
+	</ehcache:cache>
+
+	<ehcache:cache alias="KalmanErrorCache">
+		<ehcache:key-type>org.transitclock.core.dataCache.KalmanErrorCacheKey</ehcache:key-type>
+		<ehcache:value-type>org.transitclock.core.dataCache.KalmanError</ehcache:value-type>
+		<ehcache:expiry>
+			<ehcache:tti unit="days">21</ehcache:tti>
+		</ehcache:expiry>
+		<ehcache:resources>
+			<ehcache:heap unit="entries">100000</ehcache:heap>
+			<ehcache:disk persistent="true" unit="GB">1</ehcache:disk>
+		</ehcache:resources>
+	</ehcache:cache>
+
+	<ehcache:cache alias="HistoricalAverageCache">
+		<ehcache:key-type>org.transitclock.core.dataCache.StopPathCacheKey</ehcache:key-type>
+		<ehcache:value-type>org.transitclock.core.dataCache.HistoricalAverage</ehcache:value-type>
+		<ehcache:expiry>
+			<ehcache:tti unit="days">14</ehcache:tti>
+		</ehcache:expiry>
+		<ehcache:resources>
+			<ehcache:heap unit="entries">1</ehcache:heap>
+		</ehcache:resources>
+	</ehcache:cache>
+
+	<ehcache:cache alias="StopPathPredictionCache">
+		<ehcache:key-type>java.lang.Long</ehcache:key-type>
+		<ehcache:value-type>java.lang.String</ehcache:value-type>
+		<ehcache:expiry>
+			<ehcache:ttl unit="hours">1</ehcache:ttl>
+		</ehcache:expiry>
+		<ehcache:resources>
+			<ehcache:heap unit="entries">1</ehcache:heap>
+		</ehcache:resources>
+	</ehcache:cache>
+
+	<ehcache:cache alias="HoldingTimeCache">
+		<ehcache:key-type>org.transitclock.core.dataCache.HoldingTimeCacheKey</ehcache:key-type>
+		<ehcache:value-type>org.transitclock.db.structs.HoldingTime</ehcache:value-type>
+		<ehcache:expiry>
+			<ehcache:ttl unit="hours">1</ehcache:ttl>
+		</ehcache:expiry>
+		<ehcache:resources>
+			<ehcache:heap unit="entries">1</ehcache:heap>
+		</ehcache:resources>
+	</ehcache:cache>
+</ehcache:config>


### PR DESCRIPTION
## Summary

Extends the pipeline-tests suite with four behavior test classes (24 new tests) that validate previously-unobserved outputs of the prediction pipeline. Pipeline suite now runs 35 tests total (up from 11).

Each class boots a real Core via `CoreHarness` against the WMATA 5A GTFS fixture and asserts on observable state after driving AVL reports through the matcher/generator stack.

- **`PredictionGeneratorBehaviorTest`** (6 tests) — verifies `PredictionGeneratorDefaultImpl` populates `PredictionDataCache` and `VehicleState.getPredictions()` with the in-horizon stops of the current trip, carrying correct block/route/vehicle metadata and both arrival and departure variants.
- **`ArrivalDepartureBehaviorTest`** (4 tests) — drives a vehicle through two stops on block SE-08's first trip and asserts `StopArrivalDepartureCache` records a departure at the origin and an arrival at the destination with correct identifying metadata.
- **`BlockAssignerBehaviorTest`** (8 tests) — exercises BLOCK_ID / TRIP_ID / TRIP_SHORT_NAME / ROUTE_ID / UNSET assignments plus invalid-id negative cases, and covers the `getRouteIdAssignment` entry point.
- **`MatchingBehaviorTest`** (6 tests) — inspects `TemporalMatch` content: at-stop indicator, stop path index, trip/block/route references, distance-to-segment under `maxDistanceFromSegment`, populated real-time schedule adherence, and projected-location proximity to the reported AVL point.

### Infrastructure change

Adds `transitclockPipelineTests/src/test/resources/ehcache.xml` that shadows the main-classpath copy to redirect ehcache persistence from `/usr/local/transitclock/cache` (not writable under CI or most dev machines) to `target/ehcache-pipeline-store`. Needed the first time pipeline tests caused `ArrivalDepartureGeneratorDefaultImpl.updateCache` to initialize `TripDataHistoryCache`.

### Rationale

`AvlProcessorBehaviorTest` only checks `vehicle.isPredictable()` — a coarse signal. Regressions where the matcher snaps to the wrong segment, predictions carry wrong metadata, or arrival/departure records are silently dropped would all leave that check green while breaking user-visible output. These new tests close those observability gaps by asserting on actual pipeline outputs (cache contents, match fields, record metadata).

## Test plan

- [x] `mvn -pl transitclockPipelineTests -am -P include-pipeline-tests test` → 35/35 passing
- [x] `mvn verify` (default profile, no pipeline profile) → 580/580 passing, unaffected
- [x] All six test classes use per-class JVM forks via `reuseForks=false`, so adding classes doesn't risk cross-class singleton pollution

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end behavior tests covering vehicle matching, block assignment, arrival/departure event generation, and prediction generation; validate vehicle state consistency, event metadata, match distances, and prediction timing/coverage.
* **Chores**
  * Added a pipeline-test cache configuration to support local test persistence and cache behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->