### PR TITLE
Add production deployment guide and improve documentation

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -1,9 +1,21 @@
-The software is made up of three modules which can each be built with maven.
+# Build
 
-The core fuctionality is in the transitime project. The REST api is in transitimeApi and the user Web applicaton is in transitimeWebapp.
+TheTransitClock is a Maven multi-module project. From the repo root:
 
-1. transitime
-2. transitimeApi
-3. transitimeWebapp
+```bash
+mvn install -DskipTests
+```
 
-The project can be built from the root "core" directory by running "mvn install -DskipTests".
+This builds every module and produces:
+
+- Shaded executable JARs in `transitclock/target/` — one per `main` class under `org.transitclock.applications`. The most relevant for production are `Core.jar`, `GtfsFileProcessor.jar`, `SchemaGenerator.jar`, `CreateWebAgency.jar`, and `CreateAPIKey.jar`.
+- `transitclockApi/target/api.war` — the REST API.
+- `transitclockWebapp/target/web.war` — the user-facing web UI.
+
+Java 17 and Maven 3.6+ are required. There is no lint step.
+
+For the full production runbook (database provisioning, DDL generation,
+config files, running each JAR, deploying the WARs to Tomcat), see
+[docs/setup.md](docs/setup.md).
+
+For test invocation and coverage, see the README.

--- a/README.md
+++ b/README.md
@@ -4,37 +4,51 @@ This is a fork of TheTransitClock, a [GTFS-RT Trip Updates](https://gtfs.org/doc
 
 [TheTransitClock](https://thetransitclock.github.io) was developed by Sean Óg Crudden and Simon J. Berrebi, Ph.D., itself a fork of [Swiftly Transitime](https://transitime.github.io/core/).
 
-## About this Repo
+## About this repo
 
 The complete core Java software for the Transitime real-time transit information project. The purpose of the software is to use any type of real-time GPS data to generate useful public transportation information, namely a GTFS-RT Trip Updates feed.
 
-The system is for both letting passengers know the status of their vehicles and helping agencies more effectively manage their systems. By providing a complete open-source system, agencies can have a cost effective system and have full ownership of it. 
+The system is for both letting passengers know the status of their vehicles and helping agencies more effectively manage their systems. By providing a complete open-source system, agencies can have a cost effective system and have full ownership of it.
 
-## Build
+## Modules
 
-The software is made up of three modules which can each be built with maven. See [BUILD.md](./BUILD.md).
+| Module | Role |
+|---|---|
+| `transitclock` | Core engine (Java). Houses the matchers, prediction generators, Hibernate entities, RMI servers, and every `main` class under `org.transitclock.applications` (`Core`, `GtfsFileProcessor`, `SchemaGenerator`, `CreateWebAgency`, `CreateAPIKey`, `RmiQuery`, …). Builds shaded JARs into `transitclock/target/`. |
+| `transitclockApi` | JAX-RS REST API WAR. Talks to a running Core over RMI; produces the GTFS-RT TripUpdates output. |
+| `transitclockWebapp` | User-facing web UI WAR. Consumes the REST API. |
+| `transitclockQuickStart` | Single-process launcher bundling Core + API + Webapp. Convenient for local experimentation. Production deployments should run each tier as its own process — see the setup guide. |
+| `transitclockBarefootClient`, `transitclockTraccarClient` | Thin clients for Barefoot map-matching and Traccar GPS, depended on by Core. |
+| `transitclockIntegration`, `transitclockPipelineTests` | Opt-in test modules (see [docs/integration-tests.md](docs/integration-tests.md) and the profiles below). |
+| `coverage-report` | JaCoCo aggregate report (no sources of its own). |
 
-The core functionality is in the transitime project. The REST api is in transitimeApi and the user Web applicaton is in transitimeWebapp.
+## Building
 
-## Setup
+From the repo root:
 
-The main module is transitTime. This has several standalone programs in the org.transitime.applications package.
+```bash
+mvn install -DskipTests
+```
 
-SchemaGenerator.java will generate the SQL to create the database structures you need to run on.<br/>
-DBTest.java can be used to test that the database can be connected to.<br/>
-GTFSFileProcessor.java will read a GTFS file into this database structure.<br/>
-Core.java is as the name implies is the workhorse of the system. <br/>
-RmiQuery.java allows you make queries to the server run in core from the command line.<br/>
-CreateAPIKey.java a test app to allow you create test/demo key to access REST api webapp.<br/>
-CreateWebAgency.java is used to create and agency that will work in transitimeWebapp.<br/>
+This produces:
 
-Details on how to run each of these and their respective parameters are in the README for the transitime module.
+- Shaded executable JARs in `transitclock/target/` (`Core.jar`, `GtfsFileProcessor.jar`, `SchemaGenerator.jar`, `CreateWebAgency.jar`, `CreateAPIKey.jar`, `RmiQuery.jar`, `UpdateTravelTimes.jar`, `ScheduleGenerator.jar`).
+- `transitclockApi/target/api.war` and `transitclockWebapp/target/web.war` for Tomcat.
 
-Once this is set up the next step is to set up the transitimeApi which is a RESTful API. This API makes RMI calls to the RMI Server started by Core.java to provide results. This is a war file which can be deployed into Tomcat.  
+There is no lint step.
 
-The transitimeWebapp in turn is a web application which uses the transitTimeAPI to provided a user interface. This is a war file which can be deployed into Tomcat. This connects to the database and the connection information is configured in hibernate.cfg.xml in the src/main/resources directory. Currently this needs to be deployed on the same server as the API.
+## Production setup
 
-The transitimeQuickStart can be built with mvn install and ran using java -jar transitimeQuickStart it is currently a work in progress but the gui elements can be seen.
+End-to-end runbook for standing up Core against a GTFS-realtime feed, with the
+API and webapp on Tomcat: **[docs/setup.md](docs/setup.md)**.
+
+It covers:
+
+- The external data you need (GTFS static, GTFS-RT VehiclePositions, Postgres, JDK, Tomcat) and where to source it.
+- Database provisioning and DDL generation.
+- Config files (a working sample is in [`docs/examples/`](docs/examples)).
+- Running every shaded JAR with the right system properties.
+- Deploying `api.war` and `web.war` and minting an API key.
 
 ## Running tests
 

--- a/docs/examples/postgres_hibernate.cfg.xml
+++ b/docs/examples/postgres_hibernate.cfg.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE hibernate-configuration SYSTEM
+"http://www.hibernate.org/dtd/hibernate-configuration-3.0.dtd">
+
+<!--
+  Production Hibernate config for PostgreSQL.
+
+  TheTransitClock will pick up this file via the
+  -Dtransitclock.hibernate.configFile=... system property
+  (or the <hibernate><configFile> entry in transitclockConfig.xml).
+
+  Connection URL/user/password set here can be overridden at the JVM with:
+      -Dtransitclock.db.dbType=postgresql
+      -Dtransitclock.db.dbHost=localhost
+      -Dtransitclock.db.dbName=02
+      -Dtransitclock.db.dbUserName=transitclock
+      -Dtransitclock.db.dbPassword=changeme
+
+  If you don't override at the JVM, set hibernate.connection.url below.
+-->
+<hibernate-configuration>
+    <session-factory>
+
+        <property name="hibernate.dialect">org.hibernate.dialect.PostgreSQLDialect</property>
+        <property name="hibernate.connection.driver_class">org.postgresql.Driver</property>
+
+        <!-- Inline connection settings. Comment out and use system properties
+             instead if you want a single cfg.xml for multiple agencies. -->
+        <property name="hibernate.connection.url">jdbc:postgresql://localhost/02</property>
+        <property name="hibernate.connection.username">transitclock</property>
+        <property name="hibernate.connection.password">changeme</property>
+
+        <!-- Quiet logging in production. -->
+        <property name="show_sql">false</property>
+        <property name="format_sql">false</property>
+        <property name="use_sql_comments">false</property>
+
+        <!-- C3P0 pool. Required for production: Hibernate's built-in pool is
+             explicitly not safe for production use. Setting any c3p0.* property
+             switches the pool over. -->
+        <property name="hibernate.c3p0.min_size">2</property>
+        <property name="hibernate.c3p0.max_size">20</property>
+        <property name="hibernate.c3p0.timeout">300</property>
+        <property name="hibernate.c3p0.max_statements">50</property>
+
+        <!-- Batched writes — DataDbLogger pushes high-volume AVL/AD writes
+             through this. -->
+        <property name="hibernate.jdbc.batch_size">25</property>
+        <property name="default_batch_fetch_size">100</property>
+        <property name="hibernate.order_inserts">true</property>
+        <property name="hibernate.order_updates">true</property>
+        <property name="hibernate.connection.autocommit">true</property>
+
+        <!-- Schema is created up-front by SchemaGenerator + psql; we only want
+             additive changes from Hibernate, never destructive ones. -->
+        <property name="hibernate.hbm2ddl.auto">update</property>
+
+        <mapping resource="named_queries.hbm.xml" />
+
+    </session-factory>
+</hibernate-configuration>

--- a/docs/examples/transitclockConfig.xml
+++ b/docs/examples/transitclockConfig.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Production sample for TheTransitClock Core.
+
+  Pass this to Core / GtfsFileProcessor / etc. via:
+      -Dtransitclock.configFiles=/etc/transitclock/transitclockConfig.xml
+
+  Root tag MUST be <transitclock> — the XML node names become the prefix
+  of the resulting system properties (org.transitclock.config.ConfigFileReader),
+  and every typed ConfigValue in the codebase is registered under
+  transitclock.* . A root tag of <transitime> is silently ignored.
+-->
+<transitclock>
+
+    <core>
+        <agencyId>02</agencyId>
+    </core>
+
+    <modules>
+        <!-- Semicolon-separated list of Module subclasses to start as threads.
+             For a GTFS-realtime VehiclePositions feed, this is the right one. -->
+        <optionalModulesList>org.transitclock.avl.GtfsRealtimeModule</optionalModulesList>
+    </modules>
+
+    <avl>
+        <!-- VehiclePositions feed URL. Comma-separated list also accepted. -->
+        <gtfsRealtimeFeedURI>https://example.org/gtfs-realtime/vehiclePositions</gtfsRealtimeFeedURI>
+
+        <!-- Optional HTTP basic auth on the feed. -->
+        <!-- <authenticationUser>feed_user</authenticationUser> -->
+        <!-- <authenticationPassword>feed_pass</authenticationPassword> -->
+
+        <!-- Poll cadence in seconds. Default 5. -->
+        <feedPollingRateSecs>5</feedPollingRateSecs>
+
+        <!-- HTTP timeout in milliseconds. Default 10000. -->
+        <feedTimeoutInMSecs>10000</feedTimeoutInMSecs>
+
+        <!-- Optional: drop AVL outside this bbox (uncomment + set to use). -->
+        <!--
+        <minLatitude>27.0</minLatitude>
+        <maxLatitude>28.0</maxLatitude>
+        <minLongitude>-83.0</minLongitude>
+        <maxLongitude>-82.0</maxLongitude>
+        -->
+    </avl>
+
+    <hibernate>
+        <!-- Absolute path is most reliable; classpath lookup is also tried. -->
+        <configFile>/etc/transitclock/postgres_hibernate.cfg.xml</configFile>
+    </hibernate>
+
+    <autoBlockAssigner>
+        <autoAssignerEnabled>true</autoAssignerEnabled>
+    </autoBlockAssigner>
+
+</transitclock>

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,0 +1,323 @@
+# Production setup (command line)
+
+This is the power-user runbook for standing up a production TheTransitClock
+deployment from a clean machine. The flow is: build the shaded JARs, point them
+at a Postgres database, import a GTFS static feed, then run `Core.jar` against
+a GTFS-realtime vehicle-positions URL. The REST API and web UI are deployed as
+WARs into Tomcat and reach Core over RMI.
+
+This guide ignores `transitclockQuickStart` entirely. QuickStart bundles all
+three tiers into a single launcher; everything below runs each tier as its own
+process, which is what you want in production.
+
+## 1. What you need to source externally
+
+| Input | Purpose | Where to get it |
+|---|---|---|
+| **GTFS static feed** (`.zip`) | Routes, stops, trips, schedule, shapes — the static skeleton TheTransitClock matches AVL onto. | Your transit agency's open-data portal, [Mobility Database](https://database.mobilitydata.org/), or [transit.land](https://www.transit.land/feeds). Must be GTFS, not GTFS-Flex. |
+| **GTFS-realtime VehiclePositions feed** (URL) | Live AVL stream. Must be a [VehiclePositions](https://gtfs.org/documentation/realtime/feed-entities/vehicle-positions/) feed (not TripUpdates / Alerts). | Same agency or aggregator. The URL is polled every 5 s by default. HTTP basic auth and headers are supported. |
+| **PostgreSQL 12+** | Persists config, GTFS, AVL, predictions, arrivals/departures, web agency registry, and API keys. | Any standard install. MySQL also works (`-Dtransitclock.db.dbType=mysql`); HSQLDB is for tests only. |
+| **JDK 17** | Runtime. | Any LTS distribution. |
+| **Tomcat 9** | Hosts `api.war` and `web.war`. Not required if you only need the engine + RMI. | Apache Tomcat distribution. |
+
+Optional: a writable log directory (default `/Logs`, override with
+`-Dtransitclock.logging.dir=...`), and a writable PID directory (default
+`/usr/local/transitclock/`, override with `-Dtransitclock.core.pidDirectory=...`).
+
+## 2. Build the shaded JARs
+
+From the repo root:
+
+```bash
+mvn install -DskipTests
+```
+
+This drops the following self-contained executable JARs into
+`transitclock/target/`:
+
+| JAR | Main class | Role |
+|---|---|---|
+| `Core.jar` | `org.transitclock.applications.Core` | Long-running engine: ingests AVL, runs matchers, generates predictions, exposes RMI servers. |
+| `SchemaGenerator.jar` | `org.transitclock.applications.SchemaGenerator` | Emits DDL from the Hibernate-annotated entity classes. |
+| `GtfsFileProcessor.jar` | `org.transitclock.applications.GtfsFileProcessor` | One-shot GTFS static importer. |
+| `CreateWebAgency.jar` | `org.transitclock.applications.CreateWebAgency` | Registers an agency in the `web` database so the API can route RMI lookups. |
+| `CreateAPIKey.jar` | `org.transitclock.applications.CreateAPIKey` | Mints a REST API key. |
+| `RmiQuery.jar` | `org.transitclock.applications.RmiQuery` | CLI for poking a running Core's RMI servers. |
+| `UpdateTravelTimes.jar` | `org.transitclock.applications.UpdateTravelTimes` | Offline travel-time recompute over historical AD data. |
+| `ScheduleGenerator.jar` | `org.transitclock.applications.ScheduleGenerator` | Offline schedule generation. |
+
+Tomcat-deployable WARs land at:
+
+- `transitclockApi/target/api.war`
+- `transitclockWebapp/target/web.war`
+
+> `SchemaGenerator.jar` has a known classloader issue when invoked as a shaded
+> JAR (one-jar / `META-INF` collisions for Hibernate's `service-loader`-style
+> resources). Use `mvn exec:java` instead — see step 4 below. The other shaded
+> JARs run fine via `java -jar`.
+
+## 3. Provision the databases
+
+Create **two** Postgres databases. The split is enforced by the code:
+`CreateWebAgency` hardcodes its target database name to literally `web`
+(see `transitclock/src/main/java/org/transitclock/applications/CreateWebAgency.java:47`).
+Per-agency core data lives in a database whose name defaults to the agency
+ID and can be overridden with `-Dtransitclock.db.dbName=...`.
+
+```bash
+# Example: agency id "02"
+sudo -u postgres psql <<'SQL'
+CREATE USER transitclock WITH PASSWORD 'changeme';
+CREATE DATABASE "02"  OWNER transitclock;   -- core data (per agency)
+CREATE DATABASE web   OWNER transitclock;   -- WebAgency, ApiKey
+SQL
+```
+
+Naming the database after the agency id is the path of least resistance — Core
+falls back to using `transitclock.core.agencyId` as the database name when
+`transitclock.db.dbName` is unset.
+
+## 4. Generate and apply the schema
+
+Two Hibernate packages, one DDL each:
+
+- `org.transitclock.db.structs` → core tables (predictions, AVL, AD, vehicles, …)
+- `org.transitclock.db.webstructs` → web layer (`WebAgency`, `ApiKey`)
+
+Run `SchemaGenerator` via `mvn exec:java` from `transitclock/`:
+
+```bash
+cd transitclock
+mvn exec:java \
+  -Dexec.mainClass=org.transitclock.applications.SchemaGenerator \
+  -Dexec.args="-o target -p org.transitclock.db.structs"
+
+mvn exec:java \
+  -Dexec.mainClass=org.transitclock.applications.SchemaGenerator \
+  -Dexec.args="-o target -p org.transitclock.db.webstructs"
+```
+
+This writes `ddl_postgres_org_transitclock_db_structs.sql`,
+`ddl_postgres_org_transitclock_db_webstructs.sql` (and `_mysql_`, `_oracle_`
+variants) into `transitclock/target/`.
+
+Apply the right pair to the right database:
+
+```bash
+psql -U transitclock -d 02  -f target/ddl_postgres_org_transitclock_db_structs.sql
+psql -U transitclock -d web -f target/ddl_postgres_org_transitclock_db_webstructs.sql
+```
+
+## 5. Wire up configuration files
+
+You need two files. Put them somewhere stable like `/etc/transitclock/`.
+
+### 5a. `transitclockConfig.xml`
+
+This is the runtime config TheTransitClock parses on startup. The XML root tag
+becomes the property prefix — **the root must be `<transitclock>`**. A root tag
+of `<transitime>` (as appears in some legacy samples shipped with the repo) is
+silently ignored, because every typed `ConfigValue` in the codebase is
+registered under the `transitclock.*` namespace.
+
+A minimal working example is checked in at
+[`docs/examples/transitclockConfig.xml`](examples/transitclockConfig.xml).
+
+The keys you must set:
+
+| XML path | Property name | Meaning |
+|---|---|---|
+| `<transitclock><core><agencyId>` | `transitclock.core.agencyId` | Agency identifier; also default DB name. |
+| `<transitclock><modules><optionalModulesList>` | `transitclock.modules.optionalModulesList` | Semicolon-separated list of module classes to start. For GTFS-RT use `org.transitclock.avl.GtfsRealtimeModule`. |
+| `<transitclock><avl><gtfsRealtimeFeedURI>` | `transitclock.avl.gtfsRealtimeFeedURI` | URL (or comma-separated URLs) of the VehiclePositions feed. |
+| `<transitclock><hibernate><configFile>` | `transitclock.hibernate.configFile` | Path or classpath name of the Hibernate XML (next file). |
+
+Optional knobs worth knowing:
+
+- `transitclock.avl.feedPollingRateSecs` — default `5`.
+- `transitclock.avl.feedTimeoutInMSecs` — default `10000`.
+- `transitclock.avl.authenticationUser` / `transitclock.avl.authenticationPassword` — HTTP basic auth on the AVL feed.
+- `transitclock.rmi.rmiPort` — default `2099`.
+- `transitclock.rmi.secondaryRmiPort` — default `2098`.
+
+### 5b. `postgres_hibernate.cfg.xml`
+
+The Hibernate config. Connection URL/user/password can live here, or be
+overridden by `-Dtransitclock.db.dbHost=`, `-Dtransitclock.db.dbName=`,
+`-Dtransitclock.db.dbUserName=`, `-Dtransitclock.db.dbPassword=` system
+properties. A minimal example is at
+[`docs/examples/postgres_hibernate.cfg.xml`](examples/postgres_hibernate.cfg.xml).
+
+Hibernate's lookup order (`HibernateUtils.java:88-101`): filesystem first, then
+classpath. Pass an absolute path on the command line and you don't have to
+think about classpath.
+
+> The default value of `transitclock.db.dbType` is **`mysql`**. If you're on
+> Postgres you must set `-Dtransitclock.db.dbType=postgresql` (this is what
+> Core uses to construct the JDBC URL when `hibernate.connection.url` isn't
+> set in the cfg.xml).
+
+## 6. Import the GTFS static feed
+
+```bash
+java -Xmx2g \
+  -Dtransitclock.core.agencyId=02 \
+  -Dtransitclock.db.dbType=postgresql \
+  -Dtransitclock.db.dbHost=localhost \
+  -Dtransitclock.db.dbUserName=transitclock \
+  -Dtransitclock.db.dbPassword=changeme \
+  -Dtransitclock.hibernate.configFile=/etc/transitclock/postgres_hibernate.cfg.xml \
+  -jar transitclock/target/GtfsFileProcessor.jar \
+  -c /etc/transitclock/transitclockConfig.xml \
+  -gtfsZipFileName /tmp/agency-gtfs.zip \
+  -storeNewRevs
+```
+
+Critical flags:
+
+- `-c` — points at `transitclockConfig.xml` so the processor can connect to the DB.
+- `-gtfsZipFileName` — local zip; alternatively `-gtfsUrl <url>` to fetch, or `-gtfsDirectoryName <dir>` if already unzipped.
+- `-storeNewRevs` — promotes the imported revision in `ActiveRevisions` so Core picks it up. Skip this and Core will keep using the previous active rev.
+
+Useful tuning flags (full list in `transitclock/README.md`):
+`-maxTravelTimeSegmentLength`, `-maxSpeedKph`, `-maxStopToPathDistance`,
+`-trimPathBeforeFirstStopOfTrip`.
+
+## 7. Register the web agency and an API key
+
+`CreateWebAgency` writes a row into the hardcoded `web` database. **Positional
+args**, in order:
+
+```
+agencyId  hostName  dbName  dbType  dbHost  dbUserName  dbPassword
+```
+
+`hostName` is the host where Core will be reachable over RMI (this is what the
+API will look up to know where to send RMI calls). For a single-box deployment,
+use `localhost`.
+
+```bash
+java \
+  -Dtransitclock.hibernate.configFile=/etc/transitclock/postgres_hibernate.cfg.xml \
+  -Dtransitclock.db.dbType=postgresql \
+  -Dtransitclock.db.dbHost=localhost \
+  -Dtransitclock.db.dbUserName=transitclock \
+  -Dtransitclock.db.dbPassword=changeme \
+  -jar transitclock/target/CreateWebAgency.jar \
+  02 localhost 02 postgresql localhost transitclock changeme
+```
+
+Mint an API key:
+
+```bash
+java \
+  -Dtransitclock.hibernate.configFile=/etc/transitclock/postgres_hibernate.cfg.xml \
+  -Dtransitclock.db.dbType=postgresql \
+  -Dtransitclock.db.dbHost=localhost \
+  -Dtransitclock.db.dbUserName=transitclock \
+  -Dtransitclock.db.dbPassword=changeme \
+  -jar transitclock/target/CreateAPIKey.jar \
+  -c /etc/transitclock/transitclockConfig.xml \
+  -n "ops"  -u "http://localhost"  -e "ops@example.org"  -p "555-0100"  -d "Ops key"
+```
+
+The generated key is printed to stdout. Save it — REST clients pass it as a
+URL segment.
+
+## 8. Launch Core
+
+```bash
+java -Xmx4g -server \
+  -Dtransitclock.core.agencyId=02 \
+  -Dtransitclock.configFiles=/etc/transitclock/transitclockConfig.xml \
+  -Dtransitclock.hibernate.configFile=/etc/transitclock/postgres_hibernate.cfg.xml \
+  -Dtransitclock.db.dbType=postgresql \
+  -Dtransitclock.db.dbHost=localhost \
+  -Dtransitclock.db.dbUserName=transitclock \
+  -Dtransitclock.db.dbPassword=changeme \
+  -Dtransitclock.logging.dir=/var/log/transitclock \
+  -Dtransitclock.core.pidDirectory=/var/run/transitclock \
+  -jar transitclock/target/Core.jar
+```
+
+What happens on startup:
+
+1. Loads `transitclockConfig.xml` (semicolon-separated paths in `transitclock.configFiles` are supported).
+2. Reads the active GTFS revision from `ActiveRevisions` and snapshots it into `DbConfig`.
+3. Starts every class listed in `transitclock.modules.optionalModulesList` as a thread. `GtfsRealtimeModule` begins polling the feed URL.
+4. Binds RMI servers (`PredictionsServer`, `VehiclesServer`, `ConfigServer`, `CommandsServer`, `CacheQueryServer`) on port **2099**, with secondary comms on **2098**. Open these ports through any firewall between Core and your Tomcat host.
+5. Begins async batched writes to Postgres via `DataDbLogger`.
+
+Logs land at `${transitclock.logging.dir}/${agencyId}/core/YYYY/MM/DD/*.log.gz`
+(see `transitclock/src/main/resources/logback.xml:16-17`). Watch
+`avl.log.gz` and `prediction.log.gz` to confirm AVL is being ingested and
+predictions are being generated.
+
+Sanity-check from a second shell:
+
+```bash
+java -jar transitclock/target/RmiQuery.jar -a 02 -c get-vehicles
+```
+
+## 9. Deploy the API and web WARs
+
+Both WARs are vanilla Servlet 3.x apps. Drop them into Tomcat's `webapps/`.
+
+The API needs `transitclock.configFiles` and the same DB-related properties as
+Core, because it reads the `WebAgency` and `ApiKey` tables out of the `web`
+database to validate keys and route RMI lookups. The webapp depends on the API.
+
+`/etc/default/tomcat9` (or wherever you set `CATALINA_OPTS`):
+
+```bash
+CATALINA_OPTS="\
+  -Dtransitclock.configFiles=/etc/transitclock/transitclockConfig.xml \
+  -Dtransitclock.hibernate.configFile=/etc/transitclock/postgres_hibernate.cfg.xml \
+  -Dtransitclock.db.dbType=postgresql \
+  -Dtransitclock.db.dbHost=localhost \
+  -Dtransitclock.db.dbName=web \
+  -Dtransitclock.db.dbUserName=transitclock \
+  -Dtransitclock.db.dbPassword=changeme"
+```
+
+> Setting `transitclock.db.dbName=web` is what makes the API read the
+> `WebAgency` registry from the right database. Without it, lookups fall back
+> to the agency id (`WebAgency.getWebAgencyDbName()` calls
+> `DbSetupConfig.getDbName()`, which defaults to the agency id when unset).
+
+Deploy:
+
+```bash
+sudo cp transitclockApi/target/api.war        /var/lib/tomcat9/webapps/
+sudo cp transitclockWebapp/target/web.war     /var/lib/tomcat9/webapps/
+sudo systemctl restart tomcat9
+```
+
+Smoke-test the GTFS-RT TripUpdates endpoint the API generates from your live
+predictions:
+
+```bash
+curl "http://localhost:8080/api/v1/key/<API_KEY>/agency/02/command/gtfs-rt/tripUpdates?format=human"
+```
+
+The `format=human` query produces protobuf-as-text; drop it for the binary
+GTFS-RT feed.
+
+## 10. Updating GTFS
+
+When the schedule changes, re-run `GtfsFileProcessor` with the new zip and
+`-storeNewRevs`. Old revisions stay in the database (revisions are tracked by
+`configRev` and `travelTimesRev`, with `ActiveRevisions` pointing at the live
+pair), so Core continues serving until you flip the active rev. Restart Core
+after the new rev is active.
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+|---|---|
+| `Could not load in hibernate config file ...` on startup | `transitclock.hibernate.configFile` value isn't on the filesystem or classpath. Use an absolute path. |
+| Core starts but no AVL is processed | `optionalModulesList` is empty, the feed URL is wrong, or `transitclock.avl.shouldProcessAvl=false`. Check `avl.log.gz`. |
+| API returns "no agencies" / RMI timeouts | `WebAgency` row missing or pointing at a wrong host/port; `transitclock.db.dbName=web` not set in `CATALINA_OPTS`. |
+| Predictions table never grows | No active GTFS revision (forgot `-storeNewRevs`), or the AVL feed has no vehicles matching the GTFS routes/blocks. |
+| "Could not contact RMI" between API and Core | Ports 2099 and 2098 blocked, or `hostName` passed to `CreateWebAgency` doesn't resolve from the API host. |
+| Sample `transiTimeconfig.xml` settings have no effect | Root tag is `<transitime>`. Change to `<transitclock>`. |

--- a/transitclock/README.md
+++ b/transitclock/README.md
@@ -1,177 +1,171 @@
-There are several main classes which are used in the set up of the system. These can be run directly by specifying the class to run or by using the executable jar in the target directory.
+# `transitclock` — core engine
 
-The steps to set up the system are 
-<ul>
-	<li>Create Database. For this step you are on your own and you should find instructions on the related database providers web sites.
-	</li>
-	<li>Create Database structures
-		using generateDatabaseScheme.jar
-	</li>
-	</li>
-	<li>Import GTFS static data using
-		processGTFSFile.jar
-	</li>		
-	<li>Get access to a source of realtime GPS data.</li>
-	<li>Create transiTime module to read realtime GPS data or create a converter to convert the realtime datasource to a GTFS-RT vechicle location source.</li>
-	<li>Config and run core module</li>
-	<li>Create Web Agency using WebAgency class</li>
-	<li>Create API key. For the moment see TestAPIKeyManager.java test. The testAPIKeyManger test will create a key for you.</li>
-	<li>Setup transitime api webapp. Instructions to be added to README.MD in transitimeApi.</li>
-	<li>Setup transitime webapp. Instructions to be added to README.MD in transitimeWebapp.</li>
-</ul>
-	
+The core module produces the long-running `Core` JVM plus the operational tooling
+around it. Every `main` class under `org.transitclock.applications` is wired as
+its own shaded executable JAR via `transitclock/pom.xml`. After
+`mvn install -DskipTests` from the repo root, the JARs land in
+`transitclock/target/`.
 
-generateDatabaseSchema.jar -- Main class: org.transitclock.applications.SchemaGenerator
-=================================
-ISSUE: skip to ISSUE below for the moment as there is a classloader issue when using onejar.
-<br/>
-The jar generateDatabaseSchema.jar can be used to re-generate the SQL required to create the database structures required to run transiTime. It generates three files in the specified directory. A file is generated for each supported database type. (Postgres, Oracle, Mysql). The script generated will drop tables that already exist.
-<br/>
-<i>
+For a complete production runbook (databases, configs, deployment), see
+[../docs/setup.md](../docs/setup.md). This README is a per-tool reference.
 
+## Tools
 
-```
-usage: 
-	java -jar generateDatabaseSchema.jar<br/>
- 		-o,--outputDirectory <arg>        This is the directory to output the sql<br/>
- 		-p,--hibernatePackagePath <arg>   This is the path to the package
-                		                  containing the hibernate annotated java<br/>
-                                		  classes<br/>
-```                                		  
-                                   
+| JAR | Main class | Use |
+|---|---|---|
+| `Core.jar` | `org.transitclock.applications.Core` | The engine. AVL ingestion, matching, prediction generation, RMI servers. Long-running. |
+| `SchemaGenerator.jar` | `org.transitclock.applications.SchemaGenerator` | Emit DDL from the Hibernate-annotated entities. **Run via `mvn exec:java`** — the shaded jar has a one-jar/Hibernate classloader collision. |
+| `GtfsFileProcessor.jar` | `org.transitclock.applications.GtfsFileProcessor` | Import a GTFS static feed into the database. One-shot. |
+| `CreateWebAgency.jar` | `org.transitclock.applications.CreateWebAgency` | Register an agency in the `web` database so the API can route RMI lookups. |
+| `CreateAPIKey.jar` | `org.transitclock.applications.CreateAPIKey` | Mint a REST API key. |
+| `RmiQuery.jar` | `org.transitclock.applications.RmiQuery` | CLI client for a running Core's RMI servers. |
+| `UpdateTravelTimes.jar` | `org.transitclock.applications.UpdateTravelTimes` | Offline travel-time recompute over historical AD data. |
+| `ScheduleGenerator.jar` | `org.transitclock.applications.ScheduleGenerator` | Offline schedule generation. |
 
-```
-example:
-	java -jar generateDatabaseSchema.jar -o c:\temp\ -p org.transitclock.db.structs	
-```
-To create all tables require you to support the core and the webapp you could run
+## `SchemaGenerator`
 
-```
-	java -jar generateDatabaseSchema.jar -o c:\temp\core\ -p org.transitclock.db.structs
-	java -jar generateDatabaseSchema.jar -o c:\temp\web\ -p org.transitclock.db.webstructs
+Generates DDL for both schemas the deployment needs:
+
+- `org.transitclock.db.structs` — core tables (predictions, AVL, AD, vehicles, …)
+- `org.transitclock.db.webstructs` — web layer (`WebAgency`, `ApiKey`)
+
+The `mvn exec:java` form sidesteps the shaded-jar classloader issue:
+
+```bash
+cd transitclock
+mvn exec:java -Dexec.mainClass=org.transitclock.applications.SchemaGenerator \
+              -Dexec.args="-o target -p org.transitclock.db.structs"
+mvn exec:java -Dexec.mainClass=org.transitclock.applications.SchemaGenerator \
+              -Dexec.args="-o target -p org.transitclock.db.webstructs"
 ```
 
-Once these commands have been run you should run the sql created in the files in the core and web directory in your database.
-	
-ISSUE: This works in eclipse by executing the class but not on command line using the executable jar. It is an issue with the ClassLoader and onejar. Maybe better to create using mvn exec plugin.
-
-The following will can be run from the transitime directory under core and will place the required SQL in the target directory.
-```
-mvn exec:java -Dexec.mainClass="org.transitclock.applications.SchemaGenerator" -Dexec.args="-o target -p org.transitclock.db.structs"
-mvn exec:java -Dexec.mainClass="org.transitclock.applications.SchemaGenerator" -Dexec.args="-o target -p org.transitclock.db.webstructs"
-````
-
-processGTFSFile.jar -- Main class: org.transitclock.applications.GTFSFileProcessor
-=================================    
-This class the usage can be got from specifying the -h option on its own.
+Output files (one per supported dialect): `ddl_postgres_org_transitclock_db_structs.sql`, `ddl_mysql_…`, `ddl_oracle_…`, plus the `_webstructs` variants. Apply the dialect/schema pair appropriate for your database.
 
 ```
-usage: java processGTFSFile.jar [-c <configFile>] [-combineRouteNames]
-       [-defaultWaitTimeAtStopMsec <msec>] [-gtfsDirectoryName <dirName>]
-       [-gtfsUrl <url>] [-gtfsZipFileName <zipFileName>] [-h]
-       [-maxDistanceForEliminatingVertices <meters>] [-maxSpeedKph <kph>]
-       [-maxStopToPathDistance <meters>] [-maxTravelTimeSegmentLength <meters>]
-       [-n <notes>] [-pathOffsetDistance <meters>] [-regexReplaceFile
-       <fileName>] [-storeNewRevs] [-supplementDir <dirName>]
-       [-trimPathBeforeFirstStopOfTrip] [-unzipSubdirectory <dirName>]
-args:
-  -c,--config <configFile>                     Specifies configuration file to
-                                               read in. Needed for specifying
-                                               how to connect to database.
-  -combineRouteNames                           Combines short and long route
-                                               names to create full name.
-  -defaultWaitTimeAtStopMsec <msec>            For initial travel times before
-                                               AVL data used to refine them.
-                                               Specifies how long vehicle is
-                                               expected to wait at the stop.
-                                               Default is 10,000 msec (10
-                                               seconds).
-  -gtfsDirectoryName <dirName>                 Directory where unzipped GTFS
-                                               file are. Can be used if already
-                                               have current version of GTFS data
-                                               and it is already unzipped.
-  -gtfsUrl <url>                               URL where to get GTFS zip file
-                                               from. It will be copied over,
-                                               unzipped, and processed.
-  -gtfsZipFileName <zipFileName>               Local file name where the GTFS
-                                               zip file is. It will be unzipped
-                                               and processed.
-  -h                                           Display usage and help info.
-  -maxDistanceForEliminatingVertices <meters>  For consolidating vertices for a
-                                               path. If have short segments that
-                                               line up then might as combine
-                                               them. If a vertex is off the rest
-                                               of the path by only the distance
-                                               specified then the vertex will be
-                                               removed, thereby simplifying the
-                                               path. Value is in meters. Default
-                                               is 0.0m, which means that no
-                                               vertices will be eliminated.
-  -maxSpeedKph <kph>                           For initial travel times before
-                                               AVL data used to refine them.
-                                               Specifies maximum speed a vehicle
-                                               can go between stops when
-                                               determining schedule based travel
-                                               times. Default is 97kph (60mph).
-  -maxStopToPathDistance <meters>              How far a stop can be away from
-                                               the stopPaths. If the stop is
-                                               further away from the distance
-                                               then a warning message will be
-                                               output and the path will be
-                                               modified to include the stop.
-  -maxTravelTimeSegmentLength <meters>         For determining how many travel
-                                               time segments should have between
-                                               a pair of stops. Default is
-                                               200.0m, which means that many
-                                               stop stopPaths will have only a
-                                               single travel time segment
-                                               between stops.
-  -n,--notes <notes>                           Description of why processing the
-                                               GTFS data
-  -pathOffsetDistance <meters>                 When set then the shapes from
-                                               shapes.txt are offset to the
-                                               right by this distance in meters.
-                                               Useful for when shapes.txt is
-                                               street centerline data. By
-                                               offsetting the shapes then the
-                                               stopPaths for the two directions
-                                               won't overlap when zoomed in on
-                                               the map. Can use a negative
-                                               distance to adjust stopPaths to
-                                               the left instead of right, which
-                                               could be useful for countries
-                                               where one drives on the left side
-                                               of the road.
-  -regexReplaceFile <fileName>                 File that contains pairs or regex
-                                               and replacement text. The names
-                                               in the GTFS files are processed
-                                               using these replacements to fix
-                                               up spelling mistakes,
-                                               capitalization, etc.
-  -storeNewRevs                                Stores the config and travel time
-                                               revs into ActiveRevisions in
-                                               database.
-  -supplementDir <dirName>                     Directory where supplemental GTFS
-                                               files can be found. These files
-                                               are combined with the regular
-                                               GTFS files. Useful for additing
-                                               additional info such as
-                                               routeorder and hidden.
-  -trimPathBeforeFirstStopOfTrip               For trimming off path from
-                                               shapes.txt for before the first
-                                               stops of trips. Useful for when
-                                               the shapes have problems at the
-                                               beginning, which is suprisingly
-                                               common.
-  -unzipSubdirectory <dirName>                 For when unzipping GTFS files. If
-                                               set then the resulting files go
-                                               into this subdirectory.
+usage:
+    -o,--outputDirectory <arg>        Directory to write SQL files into.
+    -p,--hibernatePackagePath <arg>   Java package containing the Hibernate
+                                      annotated entity classes.
 ```
 
-```
-example:
-	java  -Xmx1000M -Dtransitime.core.agencyId=02 -jar processGTFSFile.jar -c d:/transiTime/transiTimeConfig.xml -gtfsDirectoryName d:/transiTime/updated_google_transit_irishrail/ -storeNewRevs -maxTravelTimeSegmentLength 1000
+## `GtfsFileProcessor`
+
+Imports a GTFS static feed into the database, computes initial travel times, and
+optionally promotes the resulting revision into `ActiveRevisions`.
+
+```bash
+java -Xmx2g \
+    -Dtransitclock.core.agencyId=02 \
+    -Dtransitclock.db.dbType=postgresql \
+    -Dtransitclock.db.dbHost=localhost \
+    -Dtransitclock.db.dbUserName=transitclock \
+    -Dtransitclock.db.dbPassword=changeme \
+    -Dtransitclock.hibernate.configFile=/etc/transitclock/postgres_hibernate.cfg.xml \
+    -jar target/GtfsFileProcessor.jar \
+    -c /etc/transitclock/transitclockConfig.xml \
+    -gtfsZipFileName /tmp/agency-gtfs.zip \
+    -storeNewRevs
 ```
 
+Key flags (full list with `-h`):
 
-WORK IN PROGRESS........................
+```
+-c, --config <configFile>            Config file. Required for DB connection.
+-gtfsZipFileName <zipFileName>       Local GTFS zip. Will be unzipped + processed.
+-gtfsUrl <url>                       GTFS zip URL. Will be downloaded + processed.
+-gtfsDirectoryName <dirName>         Pre-unzipped GTFS directory.
+-storeNewRevs                        Promote the new rev in ActiveRevisions.
+-supplementDir <dirName>             Supplemental GTFS files merged in.
+-maxTravelTimeSegmentLength <m>      Default 200m.
+-maxSpeedKph <kph>                   Default 97.
+-maxStopToPathDistance <m>           If a stop is farther than this from its
+                                     path it triggers a warning + path edit.
+-trimPathBeforeFirstStopOfTrip       Trim shape head before first stop.
+-defaultWaitTimeAtStopMsec <ms>      Default 10000.
+-n, --notes <notes>                  Free-text description of the import.
+-regexReplaceFile <fileName>         Spelling/case fix-ups for GTFS strings.
+```
+
+## `CreateWebAgency`
+
+Inserts a `WebAgency` row into the **`web`** database (the database name is
+hardcoded in the application's `main`). Positional args, in this exact order:
+
+```
+agencyId  hostName  dbName  dbType  dbHost  dbUserName  dbPassword
+```
+
+`hostName` is where Core is reachable over RMI from the API host.
+
+```bash
+java -Dtransitclock.hibernate.configFile=/etc/transitclock/postgres_hibernate.cfg.xml \
+     -Dtransitclock.db.dbType=postgresql \
+     -Dtransitclock.db.dbHost=localhost \
+     -Dtransitclock.db.dbUserName=transitclock \
+     -Dtransitclock.db.dbPassword=changeme \
+     -jar target/CreateWebAgency.jar \
+     02 localhost 02 postgresql localhost transitclock changeme
+```
+
+## `CreateAPIKey`
+
+```bash
+java -Dtransitclock.hibernate.configFile=/etc/transitclock/postgres_hibernate.cfg.xml \
+     -Dtransitclock.db.dbType=postgresql \
+     -Dtransitclock.db.dbHost=localhost \
+     -Dtransitclock.db.dbUserName=transitclock \
+     -Dtransitclock.db.dbPassword=changeme \
+     -jar target/CreateAPIKey.jar \
+     -c /etc/transitclock/transitclockConfig.xml \
+     -n "<application name>" \
+     -u "<application URL>" \
+     -e "<contact email>" \
+     -p "<contact phone>" \
+     -d "<description>"
+```
+
+The minted key is printed to stdout. All `-n -u -e -p -d` flags are required.
+
+## `Core`
+
+```bash
+java -Xmx4g -server \
+    -Dtransitclock.core.agencyId=02 \
+    -Dtransitclock.configFiles=/etc/transitclock/transitclockConfig.xml \
+    -Dtransitclock.hibernate.configFile=/etc/transitclock/postgres_hibernate.cfg.xml \
+    -Dtransitclock.db.dbType=postgresql \
+    -Dtransitclock.db.dbHost=localhost \
+    -Dtransitclock.db.dbUserName=transitclock \
+    -Dtransitclock.db.dbPassword=changeme \
+    -Dtransitclock.logging.dir=/var/log/transitclock \
+    -Dtransitclock.core.pidDirectory=/var/run/transitclock \
+    -jar target/Core.jar
+```
+
+System properties Core honours:
+
+| Property | Default | Notes |
+|---|---|---|
+| `transitclock.core.agencyId` | — | Required. Used as default DB name and log subdirectory. |
+| `transitclock.configFiles` | — | Required in practice. Semicolon-separated list of XML/properties config files. |
+| `transitclock.hibernate.configFile` | `hsql_hibernate.cfg.xml` | Filesystem path or classpath name. |
+| `transitclock.db.dbType` | `mysql` | **Set to `postgresql` if you're on Postgres.** |
+| `transitclock.db.dbHost` | (cfg.xml) | Override DB host. |
+| `transitclock.db.dbName` | agencyId | Override DB name. |
+| `transitclock.db.dbUserName` | (cfg.xml) | Override DB user. |
+| `transitclock.db.dbPassword` | (cfg.xml) | Override DB password. |
+| `transitclock.rmi.rmiPort` | `2099` | Primary RMI port. |
+| `transitclock.rmi.secondaryRmiPort` | `2098` | Secondary RMI port (data streams). |
+| `transitclock.logging.dir` | `/Logs` | Base directory for `logback.xml`. |
+| `transitclock.core.pidDirectory` | `/usr/local/transitclock/` | PID file location. |
+
+Logs are written to `${transitclock.logging.dir}/${agencyId}/core/YYYY/MM/DD/*.log.gz`.
+
+## `RmiQuery`
+
+Smoke-test a running Core:
+
+```bash
+java -jar target/RmiQuery.jar -a 02 -c get-vehicles
+java -jar target/RmiQuery.jar -a 02 -c get-predictions
+```

--- a/transitclock/src/main/resources/transiTimeconfig.xml
+++ b/transitclock/src/main/resources/transiTimeconfig.xml
@@ -1,24 +1,30 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<transitime>
- <modules>
-        <optionalModulesList>org.transitclock.avl.GtfsRealtimeModule</optionalModulesList>        
+<!--
+  Sample config. Root tag MUST be <transitclock> — ConfigFileReader uses
+  the XML node hierarchy as the system-property prefix, and the codebase
+  registers every ConfigValue under transitclock.* . A root tag of
+  <transitime> is silently inert.
+-->
+<transitclock>
+    <modules>
+        <optionalModulesList>org.transitclock.avl.GtfsRealtimeModule</optionalModulesList>
     </modules>
     <autoBlockAssigner><autoAssignerEnabled>true</autoAssignerEnabled></autoBlockAssigner>
     <core>
-	<agencyId>02</agencyId>
-    </core>	
+        <agencyId>02</agencyId>
+    </core>
     <avl>
-        <gtfsRealtimeFeedURI>http://realtime.prod.obahart.org:8088/vehicle-positions</gtfsRealtimeFeedURI> 		  
-		<url>http://realtime.prod.obahart.org:8088/vehicle-positions</url>	
-        <!-- URL for GTFS realtime vechicle location stream -->
-               <!--  commented out for now for ease of use -->
-   <!--      <minLatitude>30.145125</minLatitude>   
+        <gtfsRealtimeFeedURI>http://realtime.prod.obahart.org:8088/vehicle-positions</gtfsRealtimeFeedURI>
+        <url>http://realtime.prod.obahart.org:8088/vehicle-positions</url>
+        <!-- URL for GTFS realtime vehicle location stream -->
+        <!-- Optional bbox filter:
+        <minLatitude>30.145125</minLatitude>
         <maxLatitude>30.517681</maxLatitude>
-        
         <minLongitude>-98.072043</minLongitude>
-        <maxLongitude>-97.495917</maxLongitude>   -->   
-    </avl>  
+        <maxLongitude>-97.495917</maxLongitude>
+        -->
+    </avl>
     <hibernate>
-        <configFile>src/main/resources/hsql_hibernate.cfg.xml</configFile>        
+        <configFile>src/main/resources/hsql_hibernate.cfg.xml</configFile>
     </hibernate>
-</transitime>
+</transitclock>

--- a/transitclockApi/README.md
+++ b/transitclockApi/README.md
@@ -1,29 +1,58 @@
-This is the a REST service which provides the information required to run a web application or mobile application based on TheTransitClock.
+# `transitclockApi` — REST API WAR
 
-This can be built on its own by 
-```
+JAX-RS API backing TheTransitClock's user-facing webapp and any third-party
+integrations. Produces a GTFS-RT TripUpdates feed from the live predictions
+that a running `Core` JVM exposes over RMI.
+
+```bash
 cd transitclockApi
-mvn install
+mvn install -DskipTests
 ```
 
-This will produce a api.war file which can be deployed on Tomcat. 
+This produces `target/api.war`, suitable for deployment into Tomcat 9.
 
-You will need to configure the location of the transitclockConfig.xml file as a command line argument:
+## Runtime requirements
 
-`-Dtransitclock.configFiles=/path/to/your/transitclockConfig.xml`
+The API talks to two things:
 
-The exact place to do this depends on how you're running TheTransitClock. In Eclipse, add this as a VM argument in the run configuration for Tomcat. In a bash script, add it to `CATALINA_OPTS` before Tomcat starts up.
+1. A running `Core` JVM, over RMI on port **2099** (primary) and **2098** (secondary).
+2. The **`web`** database, where it reads the `WebAgency` registry (to find each agency's RMI host) and the `ApiKey` table (to authenticate REST callers).
 
-This server talks to core using RMI calls to get the information to support the REST service calls.
+So Tomcat needs the same DB credentials and config file Core uses. Set
+`CATALINA_OPTS` before starting Tomcat:
 
-To access the service a key is required to be provided in the URL. This key is compared against a key in the database. You can use the CreateAPIKey application in TheTransitClock to create a test/demo key.
-
-The tables that store this information are create by running the ddl_xxxx_org_transitime_db_webstructs.sql in the database. (Where xxxx is the type of database you are using)
+```bash
+CATALINA_OPTS="\
+  -Dtransitclock.configFiles=/etc/transitclock/transitclockConfig.xml \
+  -Dtransitclock.hibernate.configFile=/etc/transitclock/postgres_hibernate.cfg.xml \
+  -Dtransitclock.db.dbType=postgresql \
+  -Dtransitclock.db.dbHost=localhost \
+  -Dtransitclock.db.dbName=web \
+  -Dtransitclock.db.dbUserName=transitclock \
+  -Dtransitclock.db.dbPassword=changeme"
 ```
-Example URLs
 
-http://[server]:[port]/v1/transitime/key/[Key from CreateAPIKey]/agency/[agency id]/command/gtfs-rt/tripUpdates?format=human
+`-Dtransitclock.db.dbName=web` is what makes the API read the `WebAgency`
+registry from the right database. Without it, lookups fall back to using the
+agency id as the database name.
 
-http://127.0.0.1:8093/v1/transitime/key/8a3273b0/agency/02/command/gtfs-rt/tripUpdates?format=human
+## API keys
+
+REST calls authenticate via a key supplied as a URL segment. Mint one with
+`CreateAPIKey.jar` (see `transitclock/README.md`); the row lives in the `web`
+database.
+
+## Sample request
+
+```bash
+curl "http://<host>:<port>/api/v1/key/<API_KEY>/agency/<agencyId>/command/gtfs-rt/tripUpdates?format=human"
 ```
-The comments in the supporting classes are the best source of information for RESTFul calls.
+
+Drop `?format=human` for the binary protobuf feed. Routes such as
+`/v1/transitime/key/...` from older deployments are still wired up — see the
+JAX-RS root resources under `org.transitclock.api.rootResources`.
+
+## Full setup runbook
+
+See [../docs/setup.md](../docs/setup.md) for the end-to-end deployment flow
+(database provisioning, GTFS import, Core launch, WAR deployment).

--- a/transitclockWebapp/README.md
+++ b/transitclockWebapp/README.md
@@ -1,18 +1,22 @@
-This is the web application for TheTransitClock and can be built by 
+# `transitclockWebapp` — web UI WAR
 
-```
+User-facing UI on top of `transitclockApi`. Built and deployed the same way:
+
+```bash
 cd transitclockWebapp
-maven install -DskipTests
+mvn install -DskipTests
 ```
 
-This produces a war file for deployment web.war in the target directory.
+Produces `target/web.war`.
 
-You will need to configure the location of the transitclockConfig.xml file as a command line argument:
+## Runtime requirements
 
-`-Dtransitclock.configFiles=/path/to/your/transitclockConfig.xml`
+The webapp shares Tomcat with `api.war` and consumes the REST API in-process.
+It needs the same `CATALINA_OPTS` as the API (config file, Hibernate config,
+DB credentials, `transitclock.db.dbName=web`) — see
+[`transitclockApi/README.md`](../transitclockApi/README.md) and the full
+runbook in [`docs/setup.md`](../docs/setup.md).
 
-The exact place to do this depends on how you're running TheTransitClock. In Eclipse, add this as a VM argument in the run configuration for Tomcat. In a bash script, add it to `CATALINA_OPTS` before Tomcat starts up.
+## Full setup runbook
 
-The transitclockConfig.xml file in turn is used to specify the location of the database and the hibernate file.
-
-You will also need to configure the key for accessing the transitclockApi in the template/includes.jsp file. You can use the CreateAPIKey application in TheTransitClock to create a test/demo key. This you may already have done as part of the setup of transitclockApi.
+See [../docs/setup.md](../docs/setup.md).


### PR DESCRIPTION
## Summary

This PR adds comprehensive production deployment documentation and improves existing README files across the project. The changes provide operators with a complete runbook for standing up TheTransitClock in production, from database provisioning through running each tier as a separate process.

## Key changes

- **New `docs/setup.md`**: Complete 10-step production runbook covering:
  - External dependencies (GTFS feeds, PostgreSQL, JDK, Tomcat)
  - Building shaded JARs and WARs
  - Database provisioning (two separate Postgres databases)
  - Schema generation and DDL application
  - Configuration file setup (transitclockConfig.xml and Hibernate config)
  - GTFS static feed import
  - Web agency registration and API key creation
  - Core engine launch with RMI servers
  - API and web WAR deployment to Tomcat
  - GTFS updates workflow
  - Troubleshooting guide

- **New example configuration files**:
  - `docs/examples/transitclockConfig.xml`: Minimal working Core config with GTFS-RT feed setup
  - `docs/examples/postgres_hibernate.cfg.xml`: Production Hibernate config for PostgreSQL with C3P0 pooling and batched writes

- **Updated `transitclock/README.md`**: Refactored from HTML-style setup instructions to a concise tool reference with:
  - Table of all executable JARs and their purposes
  - Per-tool usage examples and flag documentation
  - Cross-reference to the full setup guide

- **Updated `transitclockApi/README.md`**: Clarified runtime requirements, database dependencies, and sample API requests

- **Updated `transitclockWebapp/README.md`**: Simplified to reference shared Tomcat configuration with the API

- **Updated `README.md`**: Added module table and build instructions, with links to detailed guides

- **Updated `BUILD.md`**: Simplified build instructions with output artifact locations

- **Updated `transitclock/src/main/resources/transiTimeconfig.xml`**: Fixed XML root tag from `<transitime>` to `<transitclock>` and improved formatting/comments

## Notable implementation details

- Documentation emphasizes the two-database split: per-agency core data (named after agency ID) and a shared `web` database for `WebAgency` and `ApiKey` tables
- Highlights that `SchemaGenerator` must be run via `mvn exec:java` due to a classloader issue with the shaded JAR
- Provides concrete examples with agency ID "02" and localhost for easy copy-paste
- Includes troubleshooting section mapping common symptoms to root causes
- Clarifies that production deployments should run Core, API, and Webapp as separate processes (not using QuickStart)

https://claude.ai/code/session_014SSFeRELttQoPi3W385nD2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced build documentation with explicit Maven commands and output locations.
  * Added comprehensive production setup guide covering schema generation, configuration wiring, and deployment steps.
  * Introduced PostgreSQL example configuration for Hibernate and production-ready application settings.
  * Improved module and tool documentation with clearer runtime requirements and example commands.
  * Streamlined README files to emphasize operational workflows and troubleshooting guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->