### PR TITLE
Phase 0.2: JAX-RS endpoint smoke suite

### DIFF
--- a/tasks.md
+++ b/tasks.md
@@ -18,7 +18,7 @@ Add green coverage of every layer the upgrade will touch on the current `javax` 
 
 ### Task 2 — Phase 0.2: JAX-RS endpoint smoke suite
 
-- **Status:** in progress
+- **Status:** completed
 - **Blocked by:** Task 1 (shares the API module test scaffolding from 0.1)
 - **Description:** One smoke test per root resource (`TransitimeApi`, `GtfsRealtimeApi`, `SiriApi`, `CommandsApi`, `CacheApi`, `TransitimeNonAgencyApi`). For each, hit one representative endpoint per HTTP method via Jersey Test Framework with mocked RMI client factories. Cover both `application/json` and `application/xml` Accept variants for the JAXB-serialized DTOs in `transitclockApi/src/main/java/org/transitclock/api/data/`.
 

--- a/tasks.md
+++ b/tasks.md
@@ -18,7 +18,7 @@ Add green coverage of every layer the upgrade will touch on the current `javax` 
 
 ### Task 2 — Phase 0.2: JAX-RS endpoint smoke suite
 
-- **Status:** pending
+- **Status:** in progress
 - **Blocked by:** Task 1 (shares the API module test scaffolding from 0.1)
 - **Description:** One smoke test per root resource (`TransitimeApi`, `GtfsRealtimeApi`, `SiriApi`, `CommandsApi`, `CacheApi`, `TransitimeNonAgencyApi`). For each, hit one representative endpoint per HTTP method via Jersey Test Framework with mocked RMI client factories. Cover both `application/json` and `application/xml` Accept variants for the JAXB-serialized DTOs in `transitclockApi/src/main/java/org/transitclock/api/data/`.
 

--- a/transitclockApi/src/test/java/org/transitclock/api/gtfsRealtime/GtfsRtTestSupport.java
+++ b/transitclockApi/src/test/java/org/transitclock/api/gtfsRealtime/GtfsRtTestSupport.java
@@ -214,38 +214,47 @@ public final class GtfsRtTestSupport {
 	/**
 	 * Seeds {@link WebAgency}'s static cache so resource handlers that call
 	 * {@link WebAgency#getCachedOrderedListOfWebAgencies()} short-circuit
-	 * past the DB read.
+	 * past the DB read. Pinning {@code webAgencyMapCacheReadTime} to
+	 * {@link Long#MAX_VALUE} makes {@code updateCacheIfShould} treat the
+	 * cache as freshly-read forever, so {@code getMapFromDb()} is never
+	 * invoked.
 	 */
 	public static void seedWebAgencies(List<WebAgency> webAgencies) {
+		// Resolve all three fields up front so a NoSuchFieldException
+		// fails fast without leaving the cache half-mutated.
+		Field mapField = webAgencyField("webAgencyMapCache");
+		Field readField = webAgencyField("webAgencyMapCacheReadTime");
+		Field orderedField = webAgencyField("webAgencyOrderedList");
 		try {
-			Field map = WebAgency.class.getDeclaredField("webAgencyMapCache");
-			map.setAccessible(true);
-			map.set(null, Collections.emptyMap());
-
-			Field read = WebAgency.class.getDeclaredField("webAgencyMapCacheReadTime");
-			read.setAccessible(true);
-			read.setLong(null, Long.MAX_VALUE);
-
-			Field ordered = WebAgency.class.getDeclaredField("webAgencyOrderedList");
-			ordered.setAccessible(true);
-			ordered.set(null, webAgencies);
-		} catch (ReflectiveOperationException e) {
+			mapField.set(null, Collections.emptyMap());
+			readField.setLong(null, Long.MAX_VALUE);
+			orderedField.set(null, webAgencies);
+		} catch (IllegalAccessException e) {
 			throw new IllegalStateException("Could not seed WebAgency cache", e);
 		}
 	}
 
 	public static void clearWebAgencies() {
+		Field mapField = webAgencyField("webAgencyMapCache");
+		Field readField = webAgencyField("webAgencyMapCacheReadTime");
+		Field orderedField = webAgencyField("webAgencyOrderedList");
 		try {
-			for (String f : new String[] { "webAgencyMapCache", "webAgencyOrderedList" }) {
-				Field field = WebAgency.class.getDeclaredField(f);
-				field.setAccessible(true);
-				field.set(null, null);
-			}
-			Field read = WebAgency.class.getDeclaredField("webAgencyMapCacheReadTime");
-			read.setAccessible(true);
-			read.setLong(null, 0L);
-		} catch (ReflectiveOperationException e) {
+			mapField.set(null, null);
+			orderedField.set(null, null);
+			readField.setLong(null, 0L);
+		} catch (IllegalAccessException e) {
 			throw new IllegalStateException("Could not clear WebAgency cache", e);
+		}
+	}
+
+	private static Field webAgencyField(String name) {
+		try {
+			Field f = WebAgency.class.getDeclaredField(name);
+			f.setAccessible(true);
+			return f;
+		} catch (NoSuchFieldException e) {
+			throw new IllegalStateException(
+					"WebAgency." + name + " no longer exists", e);
 		}
 	}
 

--- a/transitclockApi/src/test/java/org/transitclock/api/gtfsRealtime/GtfsRtTestSupport.java
+++ b/transitclockApi/src/test/java/org/transitclock/api/gtfsRealtime/GtfsRtTestSupport.java
@@ -15,10 +15,14 @@ import java.lang.reflect.Field;
 import java.util.Map;
 import java.util.TimeZone;
 
+import java.util.Collections;
+import java.util.List;
+
 import org.junit.rules.ExternalResource;
 import org.transitclock.api.utils.AgencyTimezoneCache;
 import org.transitclock.db.webstructs.ApiKey;
 import org.transitclock.db.webstructs.ApiKeyManager;
+import org.transitclock.db.webstructs.WebAgency;
 import org.transitclock.ipc.data.IpcPrediction;
 import org.transitclock.ipc.data.IpcVehicleGtfsRealtime;
 
@@ -205,6 +209,44 @@ public final class GtfsRtTestSupport {
 	public static void clearProducerCaches() {
 		clearStaticDataCache(GtfsRtVehicleFeed.class, "vehicleFeedDataCache");
 		clearStaticDataCache(GtfsRtTripFeed.class, "tripFeedDataCache");
+	}
+
+	/**
+	 * Seeds {@link WebAgency}'s static cache so resource handlers that call
+	 * {@link WebAgency#getCachedOrderedListOfWebAgencies()} short-circuit
+	 * past the DB read.
+	 */
+	public static void seedWebAgencies(List<WebAgency> webAgencies) {
+		try {
+			Field map = WebAgency.class.getDeclaredField("webAgencyMapCache");
+			map.setAccessible(true);
+			map.set(null, Collections.emptyMap());
+
+			Field read = WebAgency.class.getDeclaredField("webAgencyMapCacheReadTime");
+			read.setAccessible(true);
+			read.setLong(null, Long.MAX_VALUE);
+
+			Field ordered = WebAgency.class.getDeclaredField("webAgencyOrderedList");
+			ordered.setAccessible(true);
+			ordered.set(null, webAgencies);
+		} catch (ReflectiveOperationException e) {
+			throw new IllegalStateException("Could not seed WebAgency cache", e);
+		}
+	}
+
+	public static void clearWebAgencies() {
+		try {
+			for (String f : new String[] { "webAgencyMapCache", "webAgencyOrderedList" }) {
+				Field field = WebAgency.class.getDeclaredField(f);
+				field.setAccessible(true);
+				field.set(null, null);
+			}
+			Field read = WebAgency.class.getDeclaredField("webAgencyMapCacheReadTime");
+			read.setAccessible(true);
+			read.setLong(null, 0L);
+		} catch (ReflectiveOperationException e) {
+			throw new IllegalStateException("Could not clear WebAgency cache", e);
+		}
 	}
 
 	private static void clearStaticDataCache(Class<?> producer, String fieldName) {

--- a/transitclockApi/src/test/java/org/transitclock/api/rootResources/CacheApiSmokeTest.java
+++ b/transitclockApi/src/test/java/org/transitclock/api/rootResources/CacheApiSmokeTest.java
@@ -19,16 +19,13 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import org.glassfish.jersey.server.ResourceConfig;
-import org.junit.After;
 import org.junit.Test;
-import org.transitclock.api.gtfsRealtime.GtfsRtTestSupport;
 import org.transitclock.ipc.clients.CacheQueryInterfaceFactory;
 import org.transitclock.ipc.interfaces.CacheQueryInterface;
 
 /**
- * Smoke for {@link CacheApi}: hits {@code /command/kalmanerrorcachekeys} as
- * a representative GET in JSON and XML form. The endpoint exercises the
- * resource → CacheQueryInterface → JAXB serialization path.
+ * Smoke for {@link CacheApi}: hits {@code /command/kalmanerrorcachekeys}
+ * in JSON and XML form.
  */
 public class CacheApiSmokeTest extends JaxRsResourceSmokeBase {
 
@@ -42,25 +39,13 @@ public class CacheApiSmokeTest extends JaxRsResourceSmokeBase {
 		super.setUp();
 		CacheQueryInterface cacheIface = mock(CacheQueryInterface.class);
 		when(cacheIface.getKalmanErrorCacheKeys()).thenReturn(Collections.emptyList());
-		GtfsRtTestSupport.seedFactoryMap(CacheQueryInterfaceFactory.class,
-				"cachequeryInterfaceMap", AGENCY, cacheIface);
-	}
-
-	@After
-	@Override
-	public void tearDown() throws Exception {
-		try {
-			GtfsRtTestSupport.clearFactoryMap(CacheQueryInterfaceFactory.class,
-					"cachequeryInterfaceMap");
-		} finally {
-			super.tearDown();
-		}
+		registerFactoryMock(CacheQueryInterfaceFactory.class,
+				"cachequeryInterfaceMap", cacheIface);
 	}
 
 	@Test
 	public void kalmanErrorCacheKeysAsJson() {
-		Response r = target("/key/" + KEY + "/agency/" + AGENCY
-				+ "/command/kalmanerrorcachekeys")
+		Response r = agencyCommand("kalmanerrorcachekeys")
 				.request(MediaType.APPLICATION_JSON).get();
 
 		assertThat(r.getStatus()).isEqualTo(200);
@@ -70,8 +55,7 @@ public class CacheApiSmokeTest extends JaxRsResourceSmokeBase {
 
 	@Test
 	public void kalmanErrorCacheKeysAsXml() {
-		Response r = target("/key/" + KEY + "/agency/" + AGENCY
-				+ "/command/kalmanerrorcachekeys")
+		Response r = agencyCommand("kalmanerrorcachekeys")
 				.request(MediaType.APPLICATION_XML).get();
 
 		assertThat(r.getStatus()).isEqualTo(200);

--- a/transitclockApi/src/test/java/org/transitclock/api/rootResources/CacheApiSmokeTest.java
+++ b/transitclockApi/src/test/java/org/transitclock/api/rootResources/CacheApiSmokeTest.java
@@ -1,0 +1,81 @@
+/*
+ * This file is part of Transitime.org
+ *
+ * Transitime.org is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License (GPL) as published by the
+ * Free Software Foundation, either version 3 of the License, or any later
+ * version.
+ */
+package org.transitclock.api.rootResources;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+
+import javax.ws.rs.core.Application;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import org.glassfish.jersey.server.ResourceConfig;
+import org.junit.After;
+import org.junit.Test;
+import org.transitclock.api.gtfsRealtime.GtfsRtTestSupport;
+import org.transitclock.ipc.clients.CacheQueryInterfaceFactory;
+import org.transitclock.ipc.interfaces.CacheQueryInterface;
+
+/**
+ * Smoke for {@link CacheApi}: hits {@code /command/kalmanerrorcachekeys} as
+ * a representative GET in JSON and XML form. The endpoint exercises the
+ * resource → CacheQueryInterface → JAXB serialization path.
+ */
+public class CacheApiSmokeTest extends JaxRsResourceSmokeBase {
+
+	@Override
+	protected Application configure() {
+		return new ResourceConfig(CacheApi.class);
+	}
+
+	@Override
+	public void setUp() throws Exception {
+		super.setUp();
+		CacheQueryInterface cacheIface = mock(CacheQueryInterface.class);
+		when(cacheIface.getKalmanErrorCacheKeys()).thenReturn(Collections.emptyList());
+		GtfsRtTestSupport.seedFactoryMap(CacheQueryInterfaceFactory.class,
+				"cachequeryInterfaceMap", AGENCY, cacheIface);
+	}
+
+	@After
+	@Override
+	public void tearDown() throws Exception {
+		try {
+			GtfsRtTestSupport.clearFactoryMap(CacheQueryInterfaceFactory.class,
+					"cachequeryInterfaceMap");
+		} finally {
+			super.tearDown();
+		}
+	}
+
+	@Test
+	public void kalmanErrorCacheKeysAsJson() {
+		Response r = target("/key/" + KEY + "/agency/" + AGENCY
+				+ "/command/kalmanerrorcachekeys")
+				.request(MediaType.APPLICATION_JSON).get();
+
+		assertThat(r.getStatus()).isEqualTo(200);
+		assertThat(r.getMediaType().toString()).startsWith(MediaType.APPLICATION_JSON);
+		assertThat(r.readEntity(String.class)).isNotEmpty();
+	}
+
+	@Test
+	public void kalmanErrorCacheKeysAsXml() {
+		Response r = target("/key/" + KEY + "/agency/" + AGENCY
+				+ "/command/kalmanerrorcachekeys")
+				.request(MediaType.APPLICATION_XML).get();
+
+		assertThat(r.getStatus()).isEqualTo(200);
+		assertThat(r.getMediaType().toString()).startsWith(MediaType.APPLICATION_XML);
+		assertThat(r.readEntity(String.class)).startsWith("<?xml");
+	}
+}

--- a/transitclockApi/src/test/java/org/transitclock/api/rootResources/CacheApiSmokeTest.java
+++ b/transitclockApi/src/test/java/org/transitclock/api/rootResources/CacheApiSmokeTest.java
@@ -23,10 +23,6 @@ import org.junit.Test;
 import org.transitclock.ipc.clients.CacheQueryInterfaceFactory;
 import org.transitclock.ipc.interfaces.CacheQueryInterface;
 
-/**
- * Smoke for {@link CacheApi}: hits {@code /command/kalmanerrorcachekeys}
- * in JSON and XML form.
- */
 public class CacheApiSmokeTest extends JaxRsResourceSmokeBase {
 
 	@Override
@@ -49,7 +45,7 @@ public class CacheApiSmokeTest extends JaxRsResourceSmokeBase {
 				.request(MediaType.APPLICATION_JSON).get();
 
 		assertThat(r.getStatus()).isEqualTo(200);
-		assertThat(r.getMediaType().toString()).startsWith(MediaType.APPLICATION_JSON);
+		assertThat(r.getMediaType().isCompatible(MediaType.APPLICATION_JSON_TYPE)).isTrue();
 		assertThat(r.readEntity(String.class)).isNotEmpty();
 	}
 
@@ -59,7 +55,7 @@ public class CacheApiSmokeTest extends JaxRsResourceSmokeBase {
 				.request(MediaType.APPLICATION_XML).get();
 
 		assertThat(r.getStatus()).isEqualTo(200);
-		assertThat(r.getMediaType().toString()).startsWith(MediaType.APPLICATION_XML);
+		assertThat(r.getMediaType().isCompatible(MediaType.APPLICATION_XML_TYPE)).isTrue();
 		assertThat(r.readEntity(String.class)).startsWith("<?xml");
 	}
 }

--- a/transitclockApi/src/test/java/org/transitclock/api/rootResources/CommandsApiSmokeTest.java
+++ b/transitclockApi/src/test/java/org/transitclock/api/rootResources/CommandsApiSmokeTest.java
@@ -21,11 +21,6 @@ import org.junit.Test;
 import org.transitclock.ipc.clients.CommandsInterfaceFactory;
 import org.transitclock.ipc.interfaces.CommandsInterface;
 
-/**
- * Smoke for {@link CommandsApi}: hits {@code /command/pushAvl} once via GET
- * (query-string form) and once via POST (JSON body). Plan §0.2 calls for
- * "one representative endpoint per HTTP method".
- */
 public class CommandsApiSmokeTest extends JaxRsResourceSmokeBase {
 
 	@Override
@@ -50,7 +45,7 @@ public class CommandsApiSmokeTest extends JaxRsResourceSmokeBase {
 				.request(MediaType.APPLICATION_JSON).get();
 
 		assertThat(r.getStatus()).isEqualTo(200);
-		assertThat(r.getMediaType().toString()).startsWith(MediaType.APPLICATION_JSON);
+		assertThat(r.getMediaType().isCompatible(MediaType.APPLICATION_JSON_TYPE)).isTrue();
 		assertThat(r.readEntity(String.class)).contains("AVL processed");
 	}
 
@@ -62,7 +57,7 @@ public class CommandsApiSmokeTest extends JaxRsResourceSmokeBase {
 				.request(MediaType.APPLICATION_XML).get();
 
 		assertThat(r.getStatus()).isEqualTo(200);
-		assertThat(r.getMediaType().toString()).startsWith(MediaType.APPLICATION_XML);
+		assertThat(r.getMediaType().isCompatible(MediaType.APPLICATION_XML_TYPE)).isTrue();
 		String body = r.readEntity(String.class);
 		assertThat(body).startsWith("<?xml").contains("AVL processed");
 	}
@@ -76,6 +71,6 @@ public class CommandsApiSmokeTest extends JaxRsResourceSmokeBase {
 				.post(Entity.entity(avlBody, MediaType.APPLICATION_JSON));
 
 		assertThat(r.getStatus()).isEqualTo(200);
-		assertThat(r.getMediaType().toString()).startsWith(MediaType.APPLICATION_JSON);
+		assertThat(r.getMediaType().isCompatible(MediaType.APPLICATION_JSON_TYPE)).isTrue();
 	}
 }

--- a/transitclockApi/src/test/java/org/transitclock/api/rootResources/CommandsApiSmokeTest.java
+++ b/transitclockApi/src/test/java/org/transitclock/api/rootResources/CommandsApiSmokeTest.java
@@ -1,0 +1,98 @@
+/*
+ * This file is part of Transitime.org
+ *
+ * Transitime.org is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License (GPL) as published by the
+ * Free Software Foundation, either version 3 of the License, or any later
+ * version.
+ */
+package org.transitclock.api.rootResources;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.Application;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import org.glassfish.jersey.server.ResourceConfig;
+import org.junit.After;
+import org.junit.Test;
+import org.transitclock.api.gtfsRealtime.GtfsRtTestSupport;
+import org.transitclock.ipc.clients.CommandsInterfaceFactory;
+import org.transitclock.ipc.data.IpcAvl;
+import org.transitclock.ipc.interfaces.CommandsInterface;
+
+/**
+ * Smoke for {@link CommandsApi}: hits {@code /command/pushAvl} once via GET
+ * (query-string form) and once via POST (JSON body), each with JSON and XML
+ * accept variants. Plan §0.2 calls for "one representative endpoint per HTTP
+ * method".
+ */
+public class CommandsApiSmokeTest extends JaxRsResourceSmokeBase {
+
+	@Override
+	protected Application configure() {
+		return new ResourceConfig(CommandsApi.class);
+	}
+
+	@Override
+	public void setUp() throws Exception {
+		super.setUp();
+		CommandsInterface commandsIface = mock(CommandsInterface.class);
+		when(commandsIface.pushAvl(any(IpcAvl.class))).thenReturn("OK");
+		GtfsRtTestSupport.seedFactoryMap(CommandsInterfaceFactory.class,
+				"commandsInterfaceMap", AGENCY, commandsIface);
+	}
+
+	@After
+	@Override
+	public void tearDown() throws Exception {
+		try {
+			GtfsRtTestSupport.clearFactoryMap(CommandsInterfaceFactory.class,
+					"commandsInterfaceMap");
+		} finally {
+			super.tearDown();
+		}
+	}
+
+	@Test
+	public void pushAvlGetAsJson() {
+		Response r = target("/key/" + KEY + "/agency/" + AGENCY + "/command/pushAvl")
+				.queryParam("v", "V1").queryParam("t", "1700000000000")
+				.queryParam("lat", "38.9").queryParam("lon", "-77.0")
+				.request(MediaType.APPLICATION_JSON).get();
+
+		assertThat(r.getStatus()).isEqualTo(200);
+		assertThat(r.getMediaType().toString()).startsWith(MediaType.APPLICATION_JSON);
+		assertThat(r.readEntity(String.class)).contains("AVL processed");
+	}
+
+	@Test
+	public void pushAvlGetAsXml() {
+		Response r = target("/key/" + KEY + "/agency/" + AGENCY + "/command/pushAvl")
+				.queryParam("v", "V1").queryParam("t", "1700000000000")
+				.queryParam("lat", "38.9").queryParam("lon", "-77.0")
+				.request(MediaType.APPLICATION_XML).get();
+
+		assertThat(r.getStatus()).isEqualTo(200);
+		assertThat(r.getMediaType().toString()).startsWith(MediaType.APPLICATION_XML);
+		String body = r.readEntity(String.class);
+		assertThat(body).startsWith("<?xml").contains("AVL processed");
+	}
+
+	@Test
+	public void pushAvlPostAsJson() {
+		String avlBody = "{\"avl\":[{\"v\":\"V1\",\"t\":1700000000000,\"lat\":38.9,\"lon\":-77.0}]}";
+
+		Response r = target("/key/" + KEY + "/agency/" + AGENCY + "/command/pushAvl")
+				.request(MediaType.APPLICATION_JSON)
+				.post(Entity.entity(avlBody, MediaType.APPLICATION_JSON));
+
+		assertThat(r.getStatus()).isEqualTo(200);
+		assertThat(r.getMediaType().toString()).startsWith(MediaType.APPLICATION_JSON);
+	}
+}

--- a/transitclockApi/src/test/java/org/transitclock/api/rootResources/CommandsApiSmokeTest.java
+++ b/transitclockApi/src/test/java/org/transitclock/api/rootResources/CommandsApiSmokeTest.java
@@ -9,9 +9,7 @@
 package org.transitclock.api.rootResources;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.Application;
@@ -19,18 +17,14 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import org.glassfish.jersey.server.ResourceConfig;
-import org.junit.After;
 import org.junit.Test;
-import org.transitclock.api.gtfsRealtime.GtfsRtTestSupport;
 import org.transitclock.ipc.clients.CommandsInterfaceFactory;
-import org.transitclock.ipc.data.IpcAvl;
 import org.transitclock.ipc.interfaces.CommandsInterface;
 
 /**
  * Smoke for {@link CommandsApi}: hits {@code /command/pushAvl} once via GET
- * (query-string form) and once via POST (JSON body), each with JSON and XML
- * accept variants. Plan §0.2 calls for "one representative endpoint per HTTP
- * method".
+ * (query-string form) and once via POST (JSON body). Plan §0.2 calls for
+ * "one representative endpoint per HTTP method".
  */
 public class CommandsApiSmokeTest extends JaxRsResourceSmokeBase {
 
@@ -42,26 +36,15 @@ public class CommandsApiSmokeTest extends JaxRsResourceSmokeBase {
 	@Override
 	public void setUp() throws Exception {
 		super.setUp();
-		CommandsInterface commandsIface = mock(CommandsInterface.class);
-		when(commandsIface.pushAvl(any(IpcAvl.class))).thenReturn("OK");
-		GtfsRtTestSupport.seedFactoryMap(CommandsInterfaceFactory.class,
-				"commandsInterfaceMap", AGENCY, commandsIface);
-	}
-
-	@After
-	@Override
-	public void tearDown() throws Exception {
-		try {
-			GtfsRtTestSupport.clearFactoryMap(CommandsInterfaceFactory.class,
-					"commandsInterfaceMap");
-		} finally {
-			super.tearDown();
-		}
+		// Resource handler builds its own ApiCommandAck regardless of the
+		// CommandsInterface return value, so no method-level stubbing needed.
+		registerFactoryMock(CommandsInterfaceFactory.class, "commandsInterfaceMap",
+				mock(CommandsInterface.class));
 	}
 
 	@Test
 	public void pushAvlGetAsJson() {
-		Response r = target("/key/" + KEY + "/agency/" + AGENCY + "/command/pushAvl")
+		Response r = agencyCommand("pushAvl")
 				.queryParam("v", "V1").queryParam("t", "1700000000000")
 				.queryParam("lat", "38.9").queryParam("lon", "-77.0")
 				.request(MediaType.APPLICATION_JSON).get();
@@ -73,7 +56,7 @@ public class CommandsApiSmokeTest extends JaxRsResourceSmokeBase {
 
 	@Test
 	public void pushAvlGetAsXml() {
-		Response r = target("/key/" + KEY + "/agency/" + AGENCY + "/command/pushAvl")
+		Response r = agencyCommand("pushAvl")
 				.queryParam("v", "V1").queryParam("t", "1700000000000")
 				.queryParam("lat", "38.9").queryParam("lon", "-77.0")
 				.request(MediaType.APPLICATION_XML).get();
@@ -88,7 +71,7 @@ public class CommandsApiSmokeTest extends JaxRsResourceSmokeBase {
 	public void pushAvlPostAsJson() {
 		String avlBody = "{\"avl\":[{\"v\":\"V1\",\"t\":1700000000000,\"lat\":38.9,\"lon\":-77.0}]}";
 
-		Response r = target("/key/" + KEY + "/agency/" + AGENCY + "/command/pushAvl")
+		Response r = agencyCommand("pushAvl")
 				.request(MediaType.APPLICATION_JSON)
 				.post(Entity.entity(avlBody, MediaType.APPLICATION_JSON));
 

--- a/transitclockApi/src/test/java/org/transitclock/api/rootResources/JaxRsResourceSmokeBase.java
+++ b/transitclockApi/src/test/java/org/transitclock/api/rootResources/JaxRsResourceSmokeBase.java
@@ -1,0 +1,48 @@
+/*
+ * This file is part of Transitime.org
+ *
+ * Transitime.org is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License (GPL) as published by the
+ * Free Software Foundation, either version 3 of the License, or any later
+ * version.
+ */
+package org.transitclock.api.rootResources;
+
+import org.glassfish.jersey.test.JerseyTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.transitclock.api.gtfsRealtime.GtfsRtTestSupport;
+
+/**
+ * Common JerseyTest scaffolding for resource smoke tests: ClassRule-pinned
+ * agency timezone, API-key seeding in {@code @Before}, API-key cleanup in
+ * {@code @After}. Subclasses register their resource via
+ * {@link #configure()} and seed/clear the RMI factory maps they need.
+ */
+public abstract class JaxRsResourceSmokeBase extends JerseyTest {
+
+	protected static final String KEY = "test-key";
+	protected static final String AGENCY = GtfsRtTestSupport.AGENCY;
+
+	@ClassRule
+	public static final GtfsRtTestSupport.AgencyTimezone AGENCY_TZ =
+			new GtfsRtTestSupport.AgencyTimezone();
+
+	@Before
+	@Override
+	public void setUp() throws Exception {
+		super.setUp();
+		GtfsRtTestSupport.seedApiKeyCache(KEY);
+	}
+
+	@After
+	@Override
+	public void tearDown() throws Exception {
+		try {
+			GtfsRtTestSupport.clearApiKeyCache();
+		} finally {
+			super.tearDown();
+		}
+	}
+}

--- a/transitclockApi/src/test/java/org/transitclock/api/rootResources/JaxRsResourceSmokeBase.java
+++ b/transitclockApi/src/test/java/org/transitclock/api/rootResources/JaxRsResourceSmokeBase.java
@@ -20,14 +20,12 @@ import org.junit.ClassRule;
 import org.transitclock.api.gtfsRealtime.GtfsRtTestSupport;
 
 /**
- * Common JerseyTest scaffolding for resource smoke tests: a ClassRule-pinned
- * agency timezone, API-key seeding in {@code @Before}, and a teardown
- * registry so subclasses can {@link #registerFactoryMock} their RMI client
- * stubs without writing matching {@code @After} cleanup code.
- *
- * <p>Subclasses register their resource via {@link #configure()} and call
- * {@link #registerFactoryMock} (or {@link #registerCleanup}) in their own
- * {@code setUp} after invoking {@code super.setUp()}.
+ * JerseyTest scaffolding for the resource smoke tests. Resources read
+ * agency timezone, API keys, and RMI client interfaces from process-global
+ * static caches, so each test must seed those caches in setUp and clear
+ * them in tearDown — the {@link #registerFactoryMock} / {@link
+ * #registerCleanup} pair gives subclasses a single registration point that
+ * the base unwinds automatically.
  */
 public abstract class JaxRsResourceSmokeBase extends JerseyTest {
 
@@ -53,8 +51,13 @@ public abstract class JaxRsResourceSmokeBase extends JerseyTest {
 			for (Runnable action : teardownActions) {
 				try {
 					action.run();
-				} catch (RuntimeException keepUnwinding) {
-					// Keep unwinding remaining cleanups even if one fails.
+				} catch (RuntimeException e) {
+					// Keep unwinding remaining cleanups so one failed clear
+					// doesn't strand other static state, but surface the
+					// failure to stderr — silent leakage of static state
+					// into the next test class is the worst outcome.
+					System.err.println("Cleanup action failed: " + e);
+					e.printStackTrace(System.err);
 				}
 			}
 			teardownActions.clear();
@@ -64,10 +67,6 @@ public abstract class JaxRsResourceSmokeBase extends JerseyTest {
 		}
 	}
 
-	/**
-	 * Seeds an RMI client factory's static map with the given mock and
-	 * registers the matching {@code clearFactoryMap} to run at tearDown.
-	 */
 	protected final void registerFactoryMock(Class<?> factoryClass,
 			String mapField, Object iface) {
 		GtfsRtTestSupport.seedFactoryMap(factoryClass, mapField,
@@ -75,18 +74,15 @@ public abstract class JaxRsResourceSmokeBase extends JerseyTest {
 		registerCleanup(() -> GtfsRtTestSupport.clearFactoryMap(factoryClass, mapField));
 	}
 
-	/** Registers an arbitrary cleanup callback for tearDown. */
 	protected final void registerCleanup(Runnable action) {
 		teardownActions.add(action);
 	}
 
-	/** Builds a target under {@code /key/{KEY}/agency/{AGENCY}/command/...}. */
 	protected final WebTarget agencyCommand(String command) {
 		return target("/key/" + KEY + "/agency/" + GtfsRtTestSupport.AGENCY
 				+ "/command/" + command);
 	}
 
-	/** Builds a target under {@code /key/{KEY}/command/...} (no agency segment). */
 	protected final WebTarget keyCommand(String command) {
 		return target("/key/" + KEY + "/command/" + command);
 	}

--- a/transitclockApi/src/test/java/org/transitclock/api/rootResources/JaxRsResourceSmokeBase.java
+++ b/transitclockApi/src/test/java/org/transitclock/api/rootResources/JaxRsResourceSmokeBase.java
@@ -8,6 +8,11 @@
  */
 package org.transitclock.api.rootResources;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.ws.rs.client.WebTarget;
+
 import org.glassfish.jersey.test.JerseyTest;
 import org.junit.After;
 import org.junit.Before;
@@ -15,19 +20,24 @@ import org.junit.ClassRule;
 import org.transitclock.api.gtfsRealtime.GtfsRtTestSupport;
 
 /**
- * Common JerseyTest scaffolding for resource smoke tests: ClassRule-pinned
- * agency timezone, API-key seeding in {@code @Before}, API-key cleanup in
- * {@code @After}. Subclasses register their resource via
- * {@link #configure()} and seed/clear the RMI factory maps they need.
+ * Common JerseyTest scaffolding for resource smoke tests: a ClassRule-pinned
+ * agency timezone, API-key seeding in {@code @Before}, and a teardown
+ * registry so subclasses can {@link #registerFactoryMock} their RMI client
+ * stubs without writing matching {@code @After} cleanup code.
+ *
+ * <p>Subclasses register their resource via {@link #configure()} and call
+ * {@link #registerFactoryMock} (or {@link #registerCleanup}) in their own
+ * {@code setUp} after invoking {@code super.setUp()}.
  */
 public abstract class JaxRsResourceSmokeBase extends JerseyTest {
 
 	protected static final String KEY = "test-key";
-	protected static final String AGENCY = GtfsRtTestSupport.AGENCY;
 
 	@ClassRule
 	public static final GtfsRtTestSupport.AgencyTimezone AGENCY_TZ =
 			new GtfsRtTestSupport.AgencyTimezone();
+
+	private final List<Runnable> teardownActions = new ArrayList<>();
 
 	@Before
 	@Override
@@ -40,9 +50,44 @@ public abstract class JaxRsResourceSmokeBase extends JerseyTest {
 	@Override
 	public void tearDown() throws Exception {
 		try {
+			for (Runnable action : teardownActions) {
+				try {
+					action.run();
+				} catch (RuntimeException keepUnwinding) {
+					// Keep unwinding remaining cleanups even if one fails.
+				}
+			}
+			teardownActions.clear();
 			GtfsRtTestSupport.clearApiKeyCache();
 		} finally {
 			super.tearDown();
 		}
+	}
+
+	/**
+	 * Seeds an RMI client factory's static map with the given mock and
+	 * registers the matching {@code clearFactoryMap} to run at tearDown.
+	 */
+	protected final void registerFactoryMock(Class<?> factoryClass,
+			String mapField, Object iface) {
+		GtfsRtTestSupport.seedFactoryMap(factoryClass, mapField,
+				GtfsRtTestSupport.AGENCY, iface);
+		registerCleanup(() -> GtfsRtTestSupport.clearFactoryMap(factoryClass, mapField));
+	}
+
+	/** Registers an arbitrary cleanup callback for tearDown. */
+	protected final void registerCleanup(Runnable action) {
+		teardownActions.add(action);
+	}
+
+	/** Builds a target under {@code /key/{KEY}/agency/{AGENCY}/command/...}. */
+	protected final WebTarget agencyCommand(String command) {
+		return target("/key/" + KEY + "/agency/" + GtfsRtTestSupport.AGENCY
+				+ "/command/" + command);
+	}
+
+	/** Builds a target under {@code /key/{KEY}/command/...} (no agency segment). */
+	protected final WebTarget keyCommand(String command) {
+		return target("/key/" + KEY + "/command/" + command);
 	}
 }

--- a/transitclockApi/src/test/java/org/transitclock/api/rootResources/SiriApiSmokeTest.java
+++ b/transitclockApi/src/test/java/org/transitclock/api/rootResources/SiriApiSmokeTest.java
@@ -23,11 +23,6 @@ import org.junit.Test;
 import org.transitclock.ipc.clients.VehiclesInterfaceFactory;
 import org.transitclock.ipc.interfaces.VehiclesInterface;
 
-/**
- * Smoke for {@link SiriApi}: hits {@code /command/siri/vehicleMonitoring}
- * with empty vehicle data so the SIRI XML/JSON wrapper still serializes
- * cleanly.
- */
 public class SiriApiSmokeTest extends JaxRsResourceSmokeBase {
 
 	@Override
@@ -49,7 +44,7 @@ public class SiriApiSmokeTest extends JaxRsResourceSmokeBase {
 				.request(MediaType.APPLICATION_JSON).get();
 
 		assertThat(r.getStatus()).isEqualTo(200);
-		assertThat(r.getMediaType().toString()).startsWith(MediaType.APPLICATION_JSON);
+		assertThat(r.getMediaType().isCompatible(MediaType.APPLICATION_JSON_TYPE)).isTrue();
 		assertThat(r.readEntity(String.class)).isNotEmpty();
 	}
 
@@ -59,7 +54,7 @@ public class SiriApiSmokeTest extends JaxRsResourceSmokeBase {
 				.request(MediaType.APPLICATION_XML).get();
 
 		assertThat(r.getStatus()).isEqualTo(200);
-		assertThat(r.getMediaType().toString()).startsWith(MediaType.APPLICATION_XML);
+		assertThat(r.getMediaType().isCompatible(MediaType.APPLICATION_XML_TYPE)).isTrue();
 		assertThat(r.readEntity(String.class)).startsWith("<?xml");
 	}
 }

--- a/transitclockApi/src/test/java/org/transitclock/api/rootResources/SiriApiSmokeTest.java
+++ b/transitclockApi/src/test/java/org/transitclock/api/rootResources/SiriApiSmokeTest.java
@@ -1,0 +1,82 @@
+/*
+ * This file is part of Transitime.org
+ *
+ * Transitime.org is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License (GPL) as published by the
+ * Free Software Foundation, either version 3 of the License, or any later
+ * version.
+ */
+package org.transitclock.api.rootResources;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+
+import javax.ws.rs.core.Application;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import org.glassfish.jersey.server.ResourceConfig;
+import org.junit.After;
+import org.junit.Test;
+import org.transitclock.api.gtfsRealtime.GtfsRtTestSupport;
+import org.transitclock.ipc.clients.VehiclesInterfaceFactory;
+import org.transitclock.ipc.interfaces.VehiclesInterface;
+
+/**
+ * Smoke for {@link SiriApi}: hits {@code /command/siri/vehicleMonitoring}
+ * with empty vehicle data so the SIRI XML/JSON wrapper still serializes
+ * cleanly. Uses both JSON and XML accept variants.
+ */
+public class SiriApiSmokeTest extends JaxRsResourceSmokeBase {
+
+	@Override
+	protected Application configure() {
+		return new ResourceConfig(SiriApi.class);
+	}
+
+	@Override
+	public void setUp() throws Exception {
+		super.setUp();
+		VehiclesInterface vehiclesIface = mock(VehiclesInterface.class);
+		when(vehiclesIface.getComplete()).thenReturn(Collections.emptyList());
+		GtfsRtTestSupport.seedFactoryMap(VehiclesInterfaceFactory.class,
+				"vehiclesInterfaceMap", AGENCY, vehiclesIface);
+	}
+
+	@After
+	@Override
+	public void tearDown() throws Exception {
+		try {
+			GtfsRtTestSupport.clearFactoryMap(VehiclesInterfaceFactory.class,
+					"vehiclesInterfaceMap");
+		} finally {
+			super.tearDown();
+		}
+	}
+
+	@Test
+	public void vehicleMonitoringAsJson() {
+		Response r = target("/key/" + KEY + "/agency/" + AGENCY
+				+ "/command/siri/vehicleMonitoring")
+				.request(MediaType.APPLICATION_JSON).get();
+
+		assertThat(r.getStatus()).isEqualTo(200);
+		assertThat(r.getMediaType().toString()).startsWith(MediaType.APPLICATION_JSON);
+		assertThat(r.readEntity(String.class)).isNotEmpty();
+	}
+
+	@Test
+	public void vehicleMonitoringAsXml() {
+		Response r = target("/key/" + KEY + "/agency/" + AGENCY
+				+ "/command/siri/vehicleMonitoring")
+				.request(MediaType.APPLICATION_XML).get();
+
+		assertThat(r.getStatus()).isEqualTo(200);
+		assertThat(r.getMediaType().toString()).startsWith(MediaType.APPLICATION_XML);
+		String body = r.readEntity(String.class);
+		assertThat(body).startsWith("<?xml");
+	}
+}

--- a/transitclockApi/src/test/java/org/transitclock/api/rootResources/SiriApiSmokeTest.java
+++ b/transitclockApi/src/test/java/org/transitclock/api/rootResources/SiriApiSmokeTest.java
@@ -19,16 +19,14 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import org.glassfish.jersey.server.ResourceConfig;
-import org.junit.After;
 import org.junit.Test;
-import org.transitclock.api.gtfsRealtime.GtfsRtTestSupport;
 import org.transitclock.ipc.clients.VehiclesInterfaceFactory;
 import org.transitclock.ipc.interfaces.VehiclesInterface;
 
 /**
  * Smoke for {@link SiriApi}: hits {@code /command/siri/vehicleMonitoring}
  * with empty vehicle data so the SIRI XML/JSON wrapper still serializes
- * cleanly. Uses both JSON and XML accept variants.
+ * cleanly.
  */
 public class SiriApiSmokeTest extends JaxRsResourceSmokeBase {
 
@@ -42,25 +40,12 @@ public class SiriApiSmokeTest extends JaxRsResourceSmokeBase {
 		super.setUp();
 		VehiclesInterface vehiclesIface = mock(VehiclesInterface.class);
 		when(vehiclesIface.getComplete()).thenReturn(Collections.emptyList());
-		GtfsRtTestSupport.seedFactoryMap(VehiclesInterfaceFactory.class,
-				"vehiclesInterfaceMap", AGENCY, vehiclesIface);
-	}
-
-	@After
-	@Override
-	public void tearDown() throws Exception {
-		try {
-			GtfsRtTestSupport.clearFactoryMap(VehiclesInterfaceFactory.class,
-					"vehiclesInterfaceMap");
-		} finally {
-			super.tearDown();
-		}
+		registerFactoryMock(VehiclesInterfaceFactory.class, "vehiclesInterfaceMap", vehiclesIface);
 	}
 
 	@Test
 	public void vehicleMonitoringAsJson() {
-		Response r = target("/key/" + KEY + "/agency/" + AGENCY
-				+ "/command/siri/vehicleMonitoring")
+		Response r = agencyCommand("siri/vehicleMonitoring")
 				.request(MediaType.APPLICATION_JSON).get();
 
 		assertThat(r.getStatus()).isEqualTo(200);
@@ -70,13 +55,11 @@ public class SiriApiSmokeTest extends JaxRsResourceSmokeBase {
 
 	@Test
 	public void vehicleMonitoringAsXml() {
-		Response r = target("/key/" + KEY + "/agency/" + AGENCY
-				+ "/command/siri/vehicleMonitoring")
+		Response r = agencyCommand("siri/vehicleMonitoring")
 				.request(MediaType.APPLICATION_XML).get();
 
 		assertThat(r.getStatus()).isEqualTo(200);
 		assertThat(r.getMediaType().toString()).startsWith(MediaType.APPLICATION_XML);
-		String body = r.readEntity(String.class);
-		assertThat(body).startsWith("<?xml");
+		assertThat(r.readEntity(String.class)).startsWith("<?xml");
 	}
 }

--- a/transitclockApi/src/test/java/org/transitclock/api/rootResources/TransitimeApiSmokeTest.java
+++ b/transitclockApi/src/test/java/org/transitclock/api/rootResources/TransitimeApiSmokeTest.java
@@ -20,16 +20,13 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import org.glassfish.jersey.server.ResourceConfig;
-import org.junit.After;
 import org.junit.Test;
-import org.transitclock.api.gtfsRealtime.GtfsRtTestSupport;
 import org.transitclock.ipc.clients.ConfigInterfaceFactory;
 import org.transitclock.ipc.interfaces.ConfigInterface;
 
 /**
- * Smoke for {@link TransitimeApi}: hits {@code /command/vehicleIds} (a
- * representative GET) with both JSON and XML accept variants. The endpoint
- * exercises the resource → ConfigInterface → JAXB serialization path.
+ * Smoke for {@link TransitimeApi}: hits {@code /command/vehicleIds} with
+ * both JSON and XML accept variants.
  */
 public class TransitimeApiSmokeTest extends JaxRsResourceSmokeBase {
 
@@ -44,25 +41,12 @@ public class TransitimeApiSmokeTest extends JaxRsResourceSmokeBase {
 		List<String> vehicleIds = Arrays.asList("V1", "V2", "V3");
 		ConfigInterface configIface = mock(ConfigInterface.class);
 		when(configIface.getVehicleIds()).thenReturn(vehicleIds);
-		GtfsRtTestSupport.seedFactoryMap(ConfigInterfaceFactory.class,
-				"configInterfaceMap", AGENCY, configIface);
-	}
-
-	@After
-	@Override
-	public void tearDown() throws Exception {
-		try {
-			GtfsRtTestSupport.clearFactoryMap(ConfigInterfaceFactory.class,
-					"configInterfaceMap");
-		} finally {
-			super.tearDown();
-		}
+		registerFactoryMock(ConfigInterfaceFactory.class, "configInterfaceMap", configIface);
 	}
 
 	@Test
 	public void vehicleIdsAsJson() {
-		Response r = target("/key/" + KEY + "/agency/" + AGENCY + "/command/vehicleIds")
-				.request(MediaType.APPLICATION_JSON).get();
+		Response r = agencyCommand("vehicleIds").request(MediaType.APPLICATION_JSON).get();
 
 		assertThat(r.getStatus()).isEqualTo(200);
 		assertThat(r.getMediaType().toString()).startsWith(MediaType.APPLICATION_JSON);
@@ -72,8 +56,7 @@ public class TransitimeApiSmokeTest extends JaxRsResourceSmokeBase {
 
 	@Test
 	public void vehicleIdsAsXml() {
-		Response r = target("/key/" + KEY + "/agency/" + AGENCY + "/command/vehicleIds")
-				.request(MediaType.APPLICATION_XML).get();
+		Response r = agencyCommand("vehicleIds").request(MediaType.APPLICATION_XML).get();
 
 		assertThat(r.getStatus()).isEqualTo(200);
 		assertThat(r.getMediaType().toString()).startsWith(MediaType.APPLICATION_XML);

--- a/transitclockApi/src/test/java/org/transitclock/api/rootResources/TransitimeApiSmokeTest.java
+++ b/transitclockApi/src/test/java/org/transitclock/api/rootResources/TransitimeApiSmokeTest.java
@@ -9,10 +9,12 @@
 package org.transitclock.api.rootResources;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import javax.ws.rs.core.Application;
@@ -21,13 +23,11 @@ import javax.ws.rs.core.Response;
 
 import org.glassfish.jersey.server.ResourceConfig;
 import org.junit.Test;
+import org.transitclock.db.structs.Agency;
 import org.transitclock.ipc.clients.ConfigInterfaceFactory;
+import org.transitclock.ipc.data.IpcRouteSummary;
 import org.transitclock.ipc.interfaces.ConfigInterface;
 
-/**
- * Smoke for {@link TransitimeApi}: hits {@code /command/vehicleIds} with
- * both JSON and XML accept variants.
- */
 public class TransitimeApiSmokeTest extends JaxRsResourceSmokeBase {
 
 	@Override
@@ -38,10 +38,32 @@ public class TransitimeApiSmokeTest extends JaxRsResourceSmokeBase {
 	@Override
 	public void setUp() throws Exception {
 		super.setUp();
-		List<String> vehicleIds = Arrays.asList("V1", "V2", "V3");
+		// Materialize all dependent mocks BEFORE wiring them into the
+		// configIface stubs — Mockito's UnfinishedStubbingException fires
+		// if mock-creation runs inside another when().thenReturn(...) call.
+		List<String> ids = Arrays.asList("V1", "V2", "V3");
+		Agency agency = mock(Agency.class);
+		lenient().when(agency.getName()).thenReturn("WMATA");
+		List<Agency> agencies = Collections.singletonList(agency);
+		IpcRouteSummary route = routeSummary("5A", "5A", "Crystal City");
+		List<IpcRouteSummary> routes = Collections.singletonList(route);
+
 		ConfigInterface configIface = mock(ConfigInterface.class);
-		when(configIface.getVehicleIds()).thenReturn(vehicleIds);
+		when(configIface.getVehicleIds()).thenReturn(ids);
+		when(configIface.getAgencies()).thenReturn(agencies);
+		when(configIface.getRoutes()).thenReturn(routes);
+
 		registerFactoryMock(ConfigInterfaceFactory.class, "configInterfaceMap", configIface);
+	}
+
+	private static IpcRouteSummary routeSummary(String id, String shortName, String longName) {
+		IpcRouteSummary r = mock(IpcRouteSummary.class);
+		lenient().when(r.getId()).thenReturn(id);
+		lenient().when(r.getShortName()).thenReturn(shortName);
+		lenient().when(r.getName()).thenReturn(longName);
+		lenient().when(r.getLongName()).thenReturn(longName);
+		lenient().when(r.getType()).thenReturn("3");
+		return r;
 	}
 
 	@Test
@@ -49,7 +71,7 @@ public class TransitimeApiSmokeTest extends JaxRsResourceSmokeBase {
 		Response r = agencyCommand("vehicleIds").request(MediaType.APPLICATION_JSON).get();
 
 		assertThat(r.getStatus()).isEqualTo(200);
-		assertThat(r.getMediaType().toString()).startsWith(MediaType.APPLICATION_JSON);
+		assertThat(r.getMediaType().isCompatible(MediaType.APPLICATION_JSON_TYPE)).isTrue();
 		String body = r.readEntity(String.class);
 		assertThat(body).contains("V1").contains("V2").contains("V3");
 	}
@@ -59,9 +81,33 @@ public class TransitimeApiSmokeTest extends JaxRsResourceSmokeBase {
 		Response r = agencyCommand("vehicleIds").request(MediaType.APPLICATION_XML).get();
 
 		assertThat(r.getStatus()).isEqualTo(200);
-		assertThat(r.getMediaType().toString()).startsWith(MediaType.APPLICATION_XML);
+		assertThat(r.getMediaType().isCompatible(MediaType.APPLICATION_XML_TYPE)).isTrue();
 		String body = r.readEntity(String.class);
 		assertThat(body).contains("V1").contains("V2").contains("V3");
 		assertThat(body).startsWith("<?xml");
+	}
+
+	/**
+	 * Routes endpoint exercises a deeply-nested JAXB-serialized DTO
+	 * ({@code ApiRoutes} → {@code ApiRoute}) — the most likely site for a
+	 * Jakarta XML Bind 4.x regression in Phase B.
+	 */
+	@Test
+	public void routesAsJson() {
+		Response r = agencyCommand("routes").request(MediaType.APPLICATION_JSON).get();
+
+		assertThat(r.getStatus()).isEqualTo(200);
+		assertThat(r.getMediaType().isCompatible(MediaType.APPLICATION_JSON_TYPE)).isTrue();
+		assertThat(r.readEntity(String.class)).contains("5A");
+	}
+
+	@Test
+	public void routesAsXml() {
+		Response r = agencyCommand("routes").request(MediaType.APPLICATION_XML).get();
+
+		assertThat(r.getStatus()).isEqualTo(200);
+		assertThat(r.getMediaType().isCompatible(MediaType.APPLICATION_XML_TYPE)).isTrue();
+		String body = r.readEntity(String.class);
+		assertThat(body).startsWith("<?xml").contains("5A");
 	}
 }

--- a/transitclockApi/src/test/java/org/transitclock/api/rootResources/TransitimeApiSmokeTest.java
+++ b/transitclockApi/src/test/java/org/transitclock/api/rootResources/TransitimeApiSmokeTest.java
@@ -1,0 +1,84 @@
+/*
+ * This file is part of Transitime.org
+ *
+ * Transitime.org is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License (GPL) as published by the
+ * Free Software Foundation, either version 3 of the License, or any later
+ * version.
+ */
+package org.transitclock.api.rootResources;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.List;
+
+import javax.ws.rs.core.Application;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import org.glassfish.jersey.server.ResourceConfig;
+import org.junit.After;
+import org.junit.Test;
+import org.transitclock.api.gtfsRealtime.GtfsRtTestSupport;
+import org.transitclock.ipc.clients.ConfigInterfaceFactory;
+import org.transitclock.ipc.interfaces.ConfigInterface;
+
+/**
+ * Smoke for {@link TransitimeApi}: hits {@code /command/vehicleIds} (a
+ * representative GET) with both JSON and XML accept variants. The endpoint
+ * exercises the resource → ConfigInterface → JAXB serialization path.
+ */
+public class TransitimeApiSmokeTest extends JaxRsResourceSmokeBase {
+
+	@Override
+	protected Application configure() {
+		return new ResourceConfig(TransitimeApi.class);
+	}
+
+	@Override
+	public void setUp() throws Exception {
+		super.setUp();
+		List<String> vehicleIds = Arrays.asList("V1", "V2", "V3");
+		ConfigInterface configIface = mock(ConfigInterface.class);
+		when(configIface.getVehicleIds()).thenReturn(vehicleIds);
+		GtfsRtTestSupport.seedFactoryMap(ConfigInterfaceFactory.class,
+				"configInterfaceMap", AGENCY, configIface);
+	}
+
+	@After
+	@Override
+	public void tearDown() throws Exception {
+		try {
+			GtfsRtTestSupport.clearFactoryMap(ConfigInterfaceFactory.class,
+					"configInterfaceMap");
+		} finally {
+			super.tearDown();
+		}
+	}
+
+	@Test
+	public void vehicleIdsAsJson() {
+		Response r = target("/key/" + KEY + "/agency/" + AGENCY + "/command/vehicleIds")
+				.request(MediaType.APPLICATION_JSON).get();
+
+		assertThat(r.getStatus()).isEqualTo(200);
+		assertThat(r.getMediaType().toString()).startsWith(MediaType.APPLICATION_JSON);
+		String body = r.readEntity(String.class);
+		assertThat(body).contains("V1").contains("V2").contains("V3");
+	}
+
+	@Test
+	public void vehicleIdsAsXml() {
+		Response r = target("/key/" + KEY + "/agency/" + AGENCY + "/command/vehicleIds")
+				.request(MediaType.APPLICATION_XML).get();
+
+		assertThat(r.getStatus()).isEqualTo(200);
+		assertThat(r.getMediaType().toString()).startsWith(MediaType.APPLICATION_XML);
+		String body = r.readEntity(String.class);
+		assertThat(body).contains("V1").contains("V2").contains("V3");
+		assertThat(body).startsWith("<?xml");
+	}
+}

--- a/transitclockApi/src/test/java/org/transitclock/api/rootResources/TransitimeNonAgencyApiSmokeTest.java
+++ b/transitclockApi/src/test/java/org/transitclock/api/rootResources/TransitimeNonAgencyApiSmokeTest.java
@@ -9,8 +9,6 @@
 package org.transitclock.api.rootResources;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 import java.util.Collections;
 
@@ -19,18 +17,14 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import org.glassfish.jersey.server.ResourceConfig;
-import org.junit.After;
 import org.junit.Test;
 import org.transitclock.api.gtfsRealtime.GtfsRtTestSupport;
 import org.transitclock.db.webstructs.WebAgency;
-import org.transitclock.ipc.clients.ConfigInterfaceFactory;
-import org.transitclock.ipc.interfaces.ConfigInterface;
 
 /**
  * Smoke for {@link TransitimeNonAgencyApi}: hits {@code /command/agencies}
- * which iterates {@link WebAgency#getCachedOrderedListOfWebAgencies()} (we
- * seed it to empty so the response is a valid-but-empty {@code ApiAgencies})
- * and tests both JSON and XML serialization.
+ * which iterates {@link WebAgency#getCachedOrderedListOfWebAgencies()}. We
+ * seed it to empty so the response is a valid-but-empty {@code ApiAgencies}.
  */
 public class TransitimeNonAgencyApiSmokeTest extends JaxRsResourceSmokeBase {
 
@@ -43,31 +37,12 @@ public class TransitimeNonAgencyApiSmokeTest extends JaxRsResourceSmokeBase {
 	public void setUp() throws Exception {
 		super.setUp();
 		GtfsRtTestSupport.seedWebAgencies(Collections.emptyList());
-		// ConfigInterfaceFactory is referenced by the predictionsByLoc handler;
-		// not exercised here but seed an empty mock to keep the factory map
-		// non-null for any future tests added to this class.
-		ConfigInterface configIface = mock(ConfigInterface.class);
-		when(configIface.getAgencies()).thenReturn(Collections.emptyList());
-		GtfsRtTestSupport.seedFactoryMap(ConfigInterfaceFactory.class,
-				"configInterfaceMap", AGENCY, configIface);
-	}
-
-	@After
-	@Override
-	public void tearDown() throws Exception {
-		try {
-			GtfsRtTestSupport.clearWebAgencies();
-			GtfsRtTestSupport.clearFactoryMap(ConfigInterfaceFactory.class,
-					"configInterfaceMap");
-		} finally {
-			super.tearDown();
-		}
+		registerCleanup(GtfsRtTestSupport::clearWebAgencies);
 	}
 
 	@Test
 	public void agenciesAsJson() {
-		Response r = target("/key/" + KEY + "/command/agencies")
-				.request(MediaType.APPLICATION_JSON).get();
+		Response r = keyCommand("agencies").request(MediaType.APPLICATION_JSON).get();
 
 		assertThat(r.getStatus()).isEqualTo(200);
 		assertThat(r.getMediaType().toString()).startsWith(MediaType.APPLICATION_JSON);
@@ -76,8 +51,7 @@ public class TransitimeNonAgencyApiSmokeTest extends JaxRsResourceSmokeBase {
 
 	@Test
 	public void agenciesAsXml() {
-		Response r = target("/key/" + KEY + "/command/agencies")
-				.request(MediaType.APPLICATION_XML).get();
+		Response r = keyCommand("agencies").request(MediaType.APPLICATION_XML).get();
 
 		assertThat(r.getStatus()).isEqualTo(200);
 		assertThat(r.getMediaType().toString()).startsWith(MediaType.APPLICATION_XML);

--- a/transitclockApi/src/test/java/org/transitclock/api/rootResources/TransitimeNonAgencyApiSmokeTest.java
+++ b/transitclockApi/src/test/java/org/transitclock/api/rootResources/TransitimeNonAgencyApiSmokeTest.java
@@ -22,9 +22,9 @@ import org.transitclock.api.gtfsRealtime.GtfsRtTestSupport;
 import org.transitclock.db.webstructs.WebAgency;
 
 /**
- * Smoke for {@link TransitimeNonAgencyApi}: hits {@code /command/agencies}
- * which iterates {@link WebAgency#getCachedOrderedListOfWebAgencies()}. We
- * seed it to empty so the response is a valid-but-empty {@code ApiAgencies}.
+ * The {@code /command/agencies} handler iterates
+ * {@link WebAgency#getCachedOrderedListOfWebAgencies()} which otherwise hits
+ * the DB; seed it to empty so the response is a valid empty {@code ApiAgencies}.
  */
 public class TransitimeNonAgencyApiSmokeTest extends JaxRsResourceSmokeBase {
 
@@ -45,7 +45,7 @@ public class TransitimeNonAgencyApiSmokeTest extends JaxRsResourceSmokeBase {
 		Response r = keyCommand("agencies").request(MediaType.APPLICATION_JSON).get();
 
 		assertThat(r.getStatus()).isEqualTo(200);
-		assertThat(r.getMediaType().toString()).startsWith(MediaType.APPLICATION_JSON);
+		assertThat(r.getMediaType().isCompatible(MediaType.APPLICATION_JSON_TYPE)).isTrue();
 		assertThat(r.readEntity(String.class)).isNotEmpty();
 	}
 
@@ -54,7 +54,7 @@ public class TransitimeNonAgencyApiSmokeTest extends JaxRsResourceSmokeBase {
 		Response r = keyCommand("agencies").request(MediaType.APPLICATION_XML).get();
 
 		assertThat(r.getStatus()).isEqualTo(200);
-		assertThat(r.getMediaType().toString()).startsWith(MediaType.APPLICATION_XML);
+		assertThat(r.getMediaType().isCompatible(MediaType.APPLICATION_XML_TYPE)).isTrue();
 		assertThat(r.readEntity(String.class)).startsWith("<?xml");
 	}
 }

--- a/transitclockApi/src/test/java/org/transitclock/api/rootResources/TransitimeNonAgencyApiSmokeTest.java
+++ b/transitclockApi/src/test/java/org/transitclock/api/rootResources/TransitimeNonAgencyApiSmokeTest.java
@@ -1,0 +1,86 @@
+/*
+ * This file is part of Transitime.org
+ *
+ * Transitime.org is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License (GPL) as published by the
+ * Free Software Foundation, either version 3 of the License, or any later
+ * version.
+ */
+package org.transitclock.api.rootResources;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+
+import javax.ws.rs.core.Application;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import org.glassfish.jersey.server.ResourceConfig;
+import org.junit.After;
+import org.junit.Test;
+import org.transitclock.api.gtfsRealtime.GtfsRtTestSupport;
+import org.transitclock.db.webstructs.WebAgency;
+import org.transitclock.ipc.clients.ConfigInterfaceFactory;
+import org.transitclock.ipc.interfaces.ConfigInterface;
+
+/**
+ * Smoke for {@link TransitimeNonAgencyApi}: hits {@code /command/agencies}
+ * which iterates {@link WebAgency#getCachedOrderedListOfWebAgencies()} (we
+ * seed it to empty so the response is a valid-but-empty {@code ApiAgencies})
+ * and tests both JSON and XML serialization.
+ */
+public class TransitimeNonAgencyApiSmokeTest extends JaxRsResourceSmokeBase {
+
+	@Override
+	protected Application configure() {
+		return new ResourceConfig(TransitimeNonAgencyApi.class);
+	}
+
+	@Override
+	public void setUp() throws Exception {
+		super.setUp();
+		GtfsRtTestSupport.seedWebAgencies(Collections.emptyList());
+		// ConfigInterfaceFactory is referenced by the predictionsByLoc handler;
+		// not exercised here but seed an empty mock to keep the factory map
+		// non-null for any future tests added to this class.
+		ConfigInterface configIface = mock(ConfigInterface.class);
+		when(configIface.getAgencies()).thenReturn(Collections.emptyList());
+		GtfsRtTestSupport.seedFactoryMap(ConfigInterfaceFactory.class,
+				"configInterfaceMap", AGENCY, configIface);
+	}
+
+	@After
+	@Override
+	public void tearDown() throws Exception {
+		try {
+			GtfsRtTestSupport.clearWebAgencies();
+			GtfsRtTestSupport.clearFactoryMap(ConfigInterfaceFactory.class,
+					"configInterfaceMap");
+		} finally {
+			super.tearDown();
+		}
+	}
+
+	@Test
+	public void agenciesAsJson() {
+		Response r = target("/key/" + KEY + "/command/agencies")
+				.request(MediaType.APPLICATION_JSON).get();
+
+		assertThat(r.getStatus()).isEqualTo(200);
+		assertThat(r.getMediaType().toString()).startsWith(MediaType.APPLICATION_JSON);
+		assertThat(r.readEntity(String.class)).isNotEmpty();
+	}
+
+	@Test
+	public void agenciesAsXml() {
+		Response r = target("/key/" + KEY + "/command/agencies")
+				.request(MediaType.APPLICATION_XML).get();
+
+		assertThat(r.getStatus()).isEqualTo(200);
+		assertThat(r.getMediaType().toString()).startsWith(MediaType.APPLICATION_XML);
+		assertThat(r.readEntity(String.class)).startsWith("<?xml");
+	}
+}


### PR DESCRIPTION
## Summary

Second task in the Java 21 + Tomcat 11 + Jakarta migration plan. Adds smoke coverage of the remaining JAX-RS resources so the Jersey 2.35 → 3.1.x and javax.ws.rs → jakarta.ws.rs migration won't silently regress.

GtfsRealtimeApi was covered in Phase 0.1 (PR #14). This PR covers the other five root resources:

- `TransitimeApi` — `/command/vehicleIds` (flat `List<String>` DTO) **and** `/command/routes` (nested `ApiRoutes` → `ApiRoute` — the most likely site for a JAXB regression).
- `SiriApi` — `/command/siri/vehicleMonitoring` (SIRI XML envelope).
- `CommandsApi` — `/command/pushAvl` GET (query-string form) **and** POST (JSON body), per plan §0.2's "one representative endpoint per HTTP method".
- `CacheApi` — `/command/kalmanerrorcachekeys`.
- `TransitimeNonAgencyApi` — `/command/agencies` (no agency segment in path).

Every endpoint test runs JSON and XML accept variants (POST is JSON-only — the response body uses the same `ApiCommandAck` writer the GET-XML test exercises).

### Shared scaffolding

`JaxRsResourceSmokeBase` provides the JerseyTest container, agency-timezone `@ClassRule`, API-key seeding, and a teardown registry. Subclasses register one or more RMI client mocks via `registerFactoryMock(...)` (or `registerCleanup(...)` for arbitrary cleanups) and the base unwinds them in `tearDown`. No subclass needs to write a try/finally.

`GtfsRtTestSupport` (from Phase 0.1) gains `seedWebAgencies` / `clearWebAgencies` for the non-agency resource — its handler iterates `WebAgency.getCachedOrderedListOfWebAgencies()` which would otherwise hit Hibernate.

### Hardening from review feedback

- `tearDown` now logs swallowed cleanup exceptions to stderr — silent state leakage was the worst-case prior outcome.
- `seedWebAgencies` / `clearWebAgencies` resolve all reflection field references up front so a `NoSuchFieldException` fails fast instead of leaving partial state.
- All `MediaType` assertions use `isCompatible(...)` rather than `toString().startsWith(...)` — Jersey 3 may emit charset parameters; the substring form would break.

## Test plan

- [x] `mvn -pl transitclockApi -am test` — 53 new + existing API tests green
- [x] `mvn verify` — full reactor green
- [x] `/simplify` ran — applied
- [x] `/pr-review-toolkit:review-pr` ran — applied; no critical issues
- [ ] Re-run after Phase A (Java 21) — assertions must hold
- [ ] Re-run after Phase B (Jakarta + Jersey 3) — `isCompatible(...)` should keep these green even if Jersey adds charset params; if a JAXB schema regression hits a complex DTO, `routesAsJson`/`routesAsXml` will catch it

CI workflow scopes to PRs into `develop`/`main`/`master`, so it will not fire on this PR. Local `mvn verify` was used for verification.