### PR TITLE
Phase 0.6: Document Phase 0 test coverage in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,11 @@ jobs:
       # WAR copy to generate-resources, which only runs by package time (MDEP-187).
       # `verify` both packages and runs tests across every module.
       # Integration tests stay excluded by the default skip-integration-tests profile.
+      #
+      # Picks up the Phase 0 migration-safety tests:
+      #   * transitclockApi/src/test/    — GTFS-RT golden fixtures (0.1)
+      #                                    and JAX-RS resource smoke (0.2).
+      #   * transitclockWebapp/src/test/ — JSP taglib URI audit (0.4).
       - name: Build and run unit tests
         run: mvn -B -ntp verify
 
@@ -35,6 +40,11 @@ jobs:
       # against an in-memory HSQL database populated with a small WMATA GTFS
       # fixture and exercise matcher/generator behavior end-to-end. Separate
       # step so failures are attributed distinctly from unit-test failures.
+      #
+      # Picks up the Phase 0 migration-safety tests:
+      #   * pipelinetests/persistence/ — Hibernate Criteria pinning + entity
+      #                                  round-trip (0.3).
+      #   * pipelinetests/rmi/         — RMI server boot + client smoke (0.5).
       - name: Run pipeline tests
         run: mvn -B -ntp -pl transitclockPipelineTests -am -P include-pipeline-tests test
 

--- a/tasks.md
+++ b/tasks.md
@@ -42,7 +42,7 @@ Add green coverage of every layer the upgrade will touch on the current `javax` 
 
 ### Task 6 — Phase 0.6: Wire new tests into CI
 
-- **Status:** in progress
+- **Status:** completed
 - **Blocked by:** Tasks 1, 2, 3, 4, 5
 - **Description:** Add the new test sources to `.github/workflows/ci.yml` so they run on every PR. Run them under both `mvn verify` and `mvn install -P run-all-tests` to confirm both profiles pick them up. Consider a separate `gtfs-rt-tests` job that runs in parallel with `pipeline-tests` to keep wall time down.
 

--- a/tasks.md
+++ b/tasks.md
@@ -42,7 +42,7 @@ Add green coverage of every layer the upgrade will touch on the current `javax` 
 
 ### Task 6 — Phase 0.6: Wire new tests into CI
 
-- **Status:** pending
+- **Status:** in progress
 - **Blocked by:** Tasks 1, 2, 3, 4, 5
 - **Description:** Add the new test sources to `.github/workflows/ci.yml` so they run on every PR. Run them under both `mvn verify` and `mvn install -P run-all-tests` to confirm both profiles pick them up. Consider a separate `gtfs-rt-tests` job that runs in parallel with `pipeline-tests` to keep wall time down.
 


### PR DESCRIPTION
## Summary

Phase 0.6 of the migration plan wires Phase 0.1-0.5 test sources into CI. They're already picked up by the existing workflow steps:

| Phase | Test source | CI step |
|-------|-------------|---------|
| 0.1 | \`transitclockApi/src/test/\` GTFS-RT golden fixtures | \`mvn verify\` |
| 0.2 | \`transitclockApi/src/test/\` JAX-RS resource smoke | \`mvn verify\` |
| 0.3 | \`transitclockPipelineTests/.../persistence/\` Hibernate Criteria + round-trip | \`-P include-pipeline-tests\` |
| 0.4 | \`transitclockWebapp/src/test/\` JSP taglib audit | \`mvn verify\` |
| 0.5 | \`transitclockPipelineTests/.../rmi/\` RMI smoke | \`-P include-pipeline-tests\` |

This PR adds explanatory comments to \`.github/workflows/ci.yml\` so the coverage is auditable from the workflow file directly. Confirmed locally that \`mvn install -P run-all-tests\` succeeds end-to-end with all Phase 0 tests included (so both profile combos pick everything up, per plan §0.6).

## Test plan

- [x] \`mvn install -P run-all-tests\` — full reactor + pipeline + integration green (Tasks 1-5 included)
- [x] CI workflow comments are accurate vs file structure