### PR TITLE
Drop excessive per-stop-path and per-block log noise from GTFS import

### DIFF
--- a/transitclock/src/main/java/org/transitclock/gtfs/DbWriter.java
+++ b/transitclock/src/main/java/org/transitclock/gtfs/DbWriter.java
@@ -78,10 +78,10 @@ public class DbWriter {
 		// batching to make sure don't run out memory.
 		counter++;
 		if (counter % DbSetupConfig.getBatchSize() == 0) {
-			logger.info("flushing with " + counter + " % " + DbSetupConfig.getBatchSize());
+			logger.debug("flushing with {} % {}", counter, DbSetupConfig.getBatchSize());
 			session.flush();
 			session.clear();
-			logger.info("flushed with " + counter + " % " + DbSetupConfig.getBatchSize());
+			logger.debug("flushed with {} % {}", counter, DbSetupConfig.getBatchSize());
 		}
 	}
 	
@@ -127,8 +127,8 @@ public class DbWriter {
 		int c = 0;
 		long startTime = System.currentTimeMillis();
 		for (Block block : gtfsData.getBlocks()) {
-			logger.info("Saving block #{} with blockId={} serviceId={} blockId={}",
-					++c, block.getId(), block.getServiceId(), block.getId());
+			logger.debug("Saving block #{} with blockId={} serviceId={}",
+					++c, block.getId(), block.getServiceId());
 			writeObject(session, block, false);
 			if (c % 1000 == 0) {
 				logger.info("wrote " + c + " blocks in " + (System.currentTimeMillis()-startTime)/1000 + "s");

--- a/transitclock/src/main/java/org/transitclock/gtfs/StopPathProcessor.java
+++ b/transitclock/src/main/java/org/transitclock/gtfs/StopPathProcessor.java
@@ -421,7 +421,6 @@ public class StopPathProcessor {
 			}
 		}
 		logger.debug(" bestMatch {} expected distanceAlongPattern {}",bestMatch,stopPath.getShapeDistanceTraveled());
-		System.out.println("bestMatch "  +bestMatch+" "+stopPath.getShapeDistanceTraveled());
 		// Return results
 		return bestMatch;
 	}

--- a/transitclock/src/test/java/org/transitclock/gtfs/GtfsImportLoggingTest.java
+++ b/transitclock/src/test/java/org/transitclock/gtfs/GtfsImportLoggingTest.java
@@ -1,0 +1,80 @@
+package org.transitclock.gtfs;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import org.junit.Test;
+
+/**
+ * Pins the GTFS-import log sites that previously dominated import time when
+ * stdout is piped through Docker — thousands of stdout lines from
+ * {@link StopPathProcessor} and one INFO line per block from {@link DbWriter}.
+ * Source-level checks because triggering the real code paths requires a full
+ * TripPattern/Stop/GtfsShape graph or a Hibernate session.
+ */
+public class GtfsImportLoggingTest {
+
+    private static final Path STOP_PATH_PROCESSOR_SOURCE = moduleSource(
+            "src/main/java/org/transitclock/gtfs/StopPathProcessor.java");
+    private static final Path DB_WRITER_SOURCE = moduleSource(
+            "src/main/java/org/transitclock/gtfs/DbWriter.java");
+
+    private static final Pattern STDOUT_NOISE = Pattern.compile(
+            "System\\.(out|err)\\.(print|println|printf)|\\.printStackTrace\\(");
+
+    @Test
+    public void stopPathProcessor_doesNotPrintToStdout() throws IOException {
+        assertThat(activeLinesMatching(STOP_PATH_PROCESSOR_SOURCE, STDOUT_NOISE))
+                .isEmpty();
+    }
+
+    @Test
+    public void dbWriter_perBlockSavingMessageIsNotLoggedAtInfo() throws IOException {
+        assertThat(readSource(DB_WRITER_SOURCE))
+                .doesNotContain("logger.info(\"Saving block #");
+    }
+
+    @Test
+    public void dbWriter_flushingMessagesAreNotLoggedAtInfo() throws IOException {
+        String source = readSource(DB_WRITER_SOURCE);
+        assertThat(source).doesNotContain("logger.info(\"flushing with");
+        assertThat(source).doesNotContain("logger.info(\"flushed with");
+    }
+
+    private static String readSource(Path path) throws IOException {
+        return new String(Files.readAllBytes(path), StandardCharsets.UTF_8);
+    }
+
+    private static List<String> activeLinesMatching(Path path, Pattern pattern)
+            throws IOException {
+        List<String> hits = new ArrayList<>();
+        for (String line : Files.readAllLines(path, StandardCharsets.UTF_8)) {
+            int commentIdx = line.indexOf("//");
+            String code = commentIdx < 0 ? line : line.substring(0, commentIdx);
+            if (pattern.matcher(code).find()) {
+                hits.add(line);
+            }
+        }
+        return hits;
+    }
+
+    /** Resolves a module-relative path whether cwd is the module dir (Maven) or the repo root (some IDE configs). */
+    private static Path moduleSource(String relativePath) {
+        Path[] candidates = { Paths.get(relativePath), Paths.get("transitclock", relativePath) };
+        for (Path candidate : candidates) {
+            if (Files.exists(candidate)) {
+                return candidate;
+            }
+        }
+        throw new IllegalStateException("Could not locate " + relativePath
+                + " from cwd " + Paths.get("").toAbsolutePath());
+    }
+}


### PR DESCRIPTION
## Summary

- StopPathProcessor: delete the leftover `System.out.println` next to an existing `logger.debug` covering the same content (was emitting ~17k lines per WMATA import).
- DbWriter: drop the per-block `Saving block #...` and per-batch `flushing/flushed with...` from INFO to DEBUG. Convert the flush pair to SLF4J `{}`-templates so the per-batch concat cost is also gone when DEBUG is disabled. Drop a duplicate `blockId={}` placeholder that was logging the same value twice.
- Add `GtfsImportLoggingTest` as a source-level regression guard. Triggering the real code paths would require building a TripPattern/Stop/GtfsShape graph or a Hibernate session.

The every-1000-block `wrote N blocks in Xs` INFO line and the higher-level `Saving N blocks` header at INFO are kept — they're enough at INFO for user-facing progress.

Closes #21

## Test plan

- [x] `mvn -pl transitclock test -Dtest=GtfsImportLoggingTest` — 3 tests pass
- [x] `mvn -pl transitclock test` — all 600 tests pass
- [x] Verify on a real WMATA import that stdout is quiet at default INFO level and that DEBUG still surfaces per-block / per-batch detail when enabled

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reduced log noise by adjusting verbosity levels for periodic batch operation messages, moving them from standard to debug output for cleaner logs
  * Removed unnecessary console output from the GTFS import process

* **Tests**
  * Added automated verification tests for GTFS import logging behavior to ensure logging output meets standards

<!-- end of auto-generated comment: release notes by coderabbit.ai -->