### PR TITLE
Fix silent JVM exit 255 in GtfsFileProcessor (#24)

### DIFF
--- a/transitclock/src/main/java/org/transitclock/applications/GtfsFileProcessor.java
+++ b/transitclock/src/main/java/org/transitclock/applications/GtfsFileProcessor.java
@@ -128,11 +128,16 @@ public class GtfsFileProcessor {
 			if (configFile != null) {
 			try {
 				// Read in the data from config file
-				
+
 				ConfigFileReader.processConfig(configFile);
 			} catch (Exception e) {
 				logger.error("Error reading in config file \"" + configFile
 						+ "\". Exiting program.", e);
+				// Stderr fallback so the failure is visible even if the
+				// logback chain is broken at startup (see #24).
+				System.err.println("GtfsFileProcessor: error reading config file \""
+						+ configFile + "\"; exiting. Cause:");
+				e.printStackTrace(System.err);
 				System.exit(-1);
 			}
 			}

--- a/transitclock/src/main/java/org/transitclock/configData/DbSetupConfig.java
+++ b/transitclock/src/main/java/org/transitclock/configData/DbSetupConfig.java
@@ -82,11 +82,15 @@ public class DbSetupConfig {
 		return socketTimeoutSec.getValue();
 	}
 	public static IntegerConfigValue socketTimeoutSec =
-			new IntegerConfigValue("transitclock.db.socketTimeoutSec", 
-					60,
-					"So can set low-level socket timeout for JDBC connections. "
-					+ "Useful for when a session dies during a request, such as "
-					+ "for when a db is rebooted. Set to 0 to have no timeout.");
+			new IntegerConfigValue("transitclock.db.socketTimeoutSec",
+					0,
+					"Low-level socket timeout (seconds) appended to the JDBC URL "
+					+ "as connectTimeout/socketTimeout. Default 0 disables the "
+					+ "timeout — the previous 60 s default would kill long but "
+					+ "legitimate operations like Hibernate's hbm2ddl=update "
+					+ "schema metadata sweep on a populated DB (see #24). "
+					+ "Set to a positive value if you need fast detection of "
+					+ "dead sessions (e.g. db reboots).");
 	
 	/**
 	 * So that have flexibility with where the hibernate config file is.

--- a/transitclock/src/main/java/org/transitclock/gtfs/DbConfig.java
+++ b/transitclock/src/main/java/org/transitclock/gtfs/DbConfig.java
@@ -197,7 +197,13 @@ public class DbConfig {
 			logger.error("Error reading configuration data from db for "
 					+ "configRev={}. NOTE: Exiting because could not read in "
 					+ "data!!!!", configRev, e);
-			
+			// Stderr fallback: if the logback chain is broken (e.g. an
+			// appender failed to instantiate at startup) the logger.error
+			// above can vanish, leaving the JVM to exit 255 with no
+			// explanation. See #24.
+			System.err.println("DbConfig.read failed for configRev=" + configRev
+					+ "; exiting. Cause:");
+			e.printStackTrace(System.err);
 			System.exit(-1);
 		} finally {
 			// Usually would always make sure session gets closed. But

--- a/transitclock/src/main/resources/logback.xml
+++ b/transitclock/src/main/resources/logback.xml
@@ -100,54 +100,10 @@
 	</appender>
 
 
-	<!-- For sending out e-mails when there is a logging message that is marked
-		for notification. Usually, but not necessarily always, this will be an ERROR
-		level message. -->
-	<appender name="ERROR_SMTP" class="ch.qos.logback.classic.net.SMTPAppender">
-
-		<!-- LIST ALL E-MAIL ADDRESS HERE. Note that gmail seems to filter out
-			messages sometimes. Therefore make sure using non-gmail accounts. -->
-		<to>${logback.errorEmail}</to>
-
-		<!-- Only send e-mail if special "EMAIL" marker is specified for an ERROR
-			level message. -->
-		<evaluator class="ch.qos.logback.classic.boolex.OnMarkerEvaluator">
-			<marker>EMAIL</marker>
-		</evaluator>
-
-		<!-- Don't include messages that are DEBUG or TRACE if using cyclicBufferTracker -->
-		<filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-			<level>INFO</level>
-		</filter>
-
-		<!-- Provide just last entry. If want to can provide addition previous
-			entries (INFO, WARN, or ERROR) to provide context. -->
-		<cyclicBufferTracker class="ch.qos.logback.core.spi.CyclicBufferTracker">
-			<bufferSize>1</bufferSize>
-		</cyclicBufferTracker>
-
-		<!-- NOTE: it is important to set asynchronousSending to false. Otherwise
-			if trigger two SMTP messages within a short interval (within about 3 seconds)
-			they overwrite each other causing the first message to be delivered but to
-			have the same content as the 2nd message. Also, need async so that if program
-			exits the message is first sent. This means that if an error message sends
-			out an e-mail the thread will hang for the few seconds it takes to complete
-			the sending of the e-mail. -->
-		<asynchronousSending>false</asynchronousSending>
-
-		<!-- Specifies details of how the message is sent and the format of it -->
-		<smtpHost>${logback.smtpHost}</smtpHost>
-		<smtpPort>465</smtpPort>
-		<SSL>true</SSL>
-		<username>${logback.smtpUsername}</username>
-		<password>${logback.smtpPassword}</password>
-		<from>errorLogger@transitclock.org</from>
-		<subject>%level %logger{0} - %m</subject>
-		<layout class="ch.qos.logback.classic.PatternLayout">
-			<pattern>%d{MMM dd yyyy - HH:mm:ss.SSS} - %-5level - %logger{35}
-				:%n%message%n</pattern>
-		</layout>
-	</appender>
+	<!-- ERROR_SMTP appender removed. logback 1.3.x's SMTPAppender imports
+	     javax.mail but the project ships jakarta.mail; instantiation fails
+	     with NoClassDefFoundError, which knocks the appender (and any root
+	     logger that references it) out of the chain at startup. See #24. -->
 
 	<!-- Separate file for config parameters logging -->
 	<appender name="CONFIG"
@@ -617,9 +573,13 @@
 		another logger level was set to debug then for that class the message would
 		also be logged via root even though the logging level for root is configured
 		to be info, which is a higher level. -->
+	<!-- STDOUT on the root makes any unhandled error visible. Without it,
+	     a failure inside Core / DbConfig that ends in System.exit silently
+	     vanishes (see #24). The CORE rolling-file appender stays for
+	     archival; STDOUT is for live container logs. -->
 	<root level="info">
 		<appender-ref ref="CORE" />
-		<appender-ref ref="ERROR_SMTP" />
+		<appender-ref ref="STDOUT" />
 	</root>
 
 </configuration>


### PR DESCRIPTION
## Summary

Fixes #24 — a freshly-built `transitclock/tools` image could not run `GtfsFileProcessor.jar`: the JVM exited 255 within seconds of Hibernate startup, with no error on stdout, stderr, or in `core.log`, blocking the quickstart at the GTFS-import step.

Three problems chained into the silent failure:

- **Broken logback appender.** `logback.xml` referenced an `ERROR_SMTP` appender backed by logback 1.3.x's `SMTPAppender`, which still imports `javax.mail`. The project now ships `jakarta.mail`, so the appender failed to instantiate at startup with `NoClassDefFoundError`. Because the root logger only referenced `CORE` (file) + `ERROR_SMTP`, any `logger.error` after that landed in `core.log` only — and any failure in the file appender chain was lost.
- **JDBC socket timeout killing the metadata sweep.** `DbSetupConfig.socketTimeoutSec` defaulted to 60 s and was appended to the JDBC URL as `connectTimeout`/`socketTimeout`. Hibernate's `hbm2ddl=update` metadata sweep against the populated WMATA schema exceeded that budget; the driver closed the connection mid-statement, `JDBCConnectionException` propagated up, and `DbConfig.read` called `System.exit(-1)`.
- **No System.err fallback on the System.exit path.** The exit went through `logger.error` only, so once the appender chain was broken the process disappeared without any visible message.

### Fix

- Drop the `ERROR_SMTP` appender from `logback.xml` and add `STDOUT` to the root logger so unhandled errors show up on container stdout.
- Add a `System.err` fallback in `DbConfig.read` and `GtfsFileProcessor`'s config-read catch so a `System.exit`-on-error always prints a stack, even if logback is misconfigured.
- Default `socketTimeoutSec` to 0 (no JDBC-level timeout). Operators that want fast dead-session detection can still set the property; c3p0's connection tester remains in place for pool-level liveness.

### Verification

Ran the issue's repro recipe verbatim against a freshly-rebuilt `tools` image:

```bash
docker compose down -v && rm -rf .deploy/.state .deploy/conf .deploy/ddl
./quickstart.sh --gtfs-zip .deploy/wmata-gtfs.zip --avl-url https://example.org/placeholder.pb
```

- GtfsFileProcessor now runs past the previous silent-exit point and into Hibernate's `hbm2ddl=update` constraint sweep (the operation the `socketTimeoutSec` change targets).
- Full WMATA import completes: `Finished writing GTFS data to database. Took 166559 msec.` `Finished processing GTFS data from /deploy. Took 181628 msec.`
- DB rowcounts: 126 routes, 97,584 trips, 7,552 stops, 16,723 stopPaths.
- Quickstart reaches its terminal `==> Done. Stack is up.` line; all state markers (`gtfs-imported`, `web-agency-created`, `api-key-minted`) present.

## Test plan

- [x] Quickstart end-to-end on a freshly rebuilt `tools` image
- [x] GtfsFileProcessor produces visible logs past the previous silent-exit point
- [x] WMATA GTFS data persisted to Postgres (rowcount sanity check)
- [x] Core + Tomcat services start (stack-up reached)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Configuration file and database initialization errors now display detailed messages to console output
  * Removed non-functional SMTP email notifications; console output now captures unhandled errors that previously could fail silently

* **Configuration**
  * Database socket timeout default changed from 60 seconds to unlimited, supporting longer-running database operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->