### PR TITLE
Bump hibernate.jdbc.batch_size from 50 to 100

### DIFF
--- a/docs/examples/postgres_hibernate.cfg.xml
+++ b/docs/examples/postgres_hibernate.cfg.xml
@@ -57,7 +57,7 @@
         <!-- Batched writes — DataDbLogger and DbWriter both push through
              this. Should evenly divide transitclock.db.batchSize so each
              DbWriter flush ships a whole number of JDBC batches. -->
-        <property name="hibernate.jdbc.batch_size">50</property>
+        <property name="hibernate.jdbc.batch_size">100</property>
         <property name="default_batch_fetch_size">100</property>
         <property name="hibernate.order_inserts">true</property>
         <property name="hibernate.order_updates">true</property>


### PR DESCRIPTION
## Summary

- Sets `hibernate.jdbc.batch_size` to 100 in `docs/examples/postgres_hibernate.cfg.xml` so each `DbWriter` flush (`transitclock.db.batchSize=100`) ships exactly one full JDBC batch instead of two half-batches.
- Closes the loop on the experiment proposed in #27.

## Benchmark — fresh WMATA quickstart, both runs against a freshly torn-down stack

| Metric | Before (50) | After (100) | Δ |
|---|---|---|---|
| `DbWriter — Finished writing GTFS data` | 164,366 ms | 156,096 ms | **−8,270 ms (−5.0%)** |
| 12,000-block hot loop | 158 s | 151 s | −7 s (−4.4%) |

Per-1000-block cumulative seconds (the divergence is monotonic from block 4000 on, so it isn't run-to-run noise):
```
before: 13, 24, 38, 49, 62, 76, 87, 101, 117, 131, 144, 158
after:  13, 24, 38, 48, 60, 74, 85,  98, 113, 125, 137, 151
```

End-to-end verification on the AFTER run: 12,407 blocks, 97,584 trips, 82,951 travel-times-for-trips, 7,552 stops, and 126 routes all landed in Postgres; Core + Tomcat came up healthy.

## Notes for the reviewer

- The improvement is real but smaller than #27 hoped. That suggests the wire-chunk cap PG was logging at 32 rows isn't actually `hibernate.jdbc.batch_size` — most likely it lives in pgjdbc's `rewriteBatchedInserts` chunking. Tracking that down (and confirming with `log_statement=mod`) is a follow-up.
- DataDbLogger also uses this property. Live AVL/AD rows are small; doubling the buffer is fine for them too. Worth a quick smoke under load if you want to be paranoid, but I don't think it changes anything.
- Inline comment on the property still applies: 100 evenly divides `transitclock.db.batchSize=100`, so each flush ships a whole number (1) of JDBC batches.

## Test plan

- [x] `docker compose down -v && rm -rf .deploy` for a clean BEFORE run; quickstart with batch_size=50; import logged 164,366 ms.
- [x] `docker compose down -v && rm -rf .deploy` again; bumped value to 100; quickstart with batch_size=100 imported 12,407 blocks successfully in 156,096 ms.
- [x] Verified row counts in Postgres (`blocks=12407`, `trips=97584`, `traveltimesfortrips=82951`, `stops=7552`, `routes=126`).
- [x] Stack came up healthy after the AFTER run (`docker compose ps` clean; API container responds with 401 to a stale key, i.e. the API is alive).

Refs #27.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated example configuration parameters to reflect improved performance tuning recommendations for database batch operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->