### PR TITLE
Modernize synoptic page UI

### DIFF
--- a/transitclockWebapp/src/main/webapp/synoptic/css/synoptic.css
+++ b/transitclockWebapp/src/main/webapp/synoptic/css/synoptic.css
@@ -1,235 +1,243 @@
+#synoptic {
+	position: absolute;
+	left: 0;
+	right: 0;
+	top: 0;
+	bottom: 14px;
+	overflow-x: scroll;
+	overflow-y: hidden;
+	background: #fff;
+}
 
-.tooltip-left{
+/* macOS overlay scrollbars auto-hide, so we paint our own. */
+#synopticScrollbar {
+	position: absolute;
+	left: 0;
+	right: 0;
+	bottom: 0;
+	height: 14px;
+	background: #f3f4f6;
+	border-top: 1px solid #e5e7eb;
+	cursor: pointer;
+	overflow: hidden;
+	display: none;
+}
+
+#synopticScrollThumb {
+	position: absolute;
+	top: 2px;
+	bottom: 2px;
+	left: 0;
+	min-width: 40px;
+	background: #9ca3af;
+	border-radius: 5px;
+	cursor: grab;
+	transition: background 0.15s;
+}
+
+#synopticScrollThumb:hover {
+	background: #6b7280;
+}
+
+#synopticScrollThumb.dragging {
+	background: #4b5563;
+	cursor: grabbing;
+	transition: none;
+}
+
+#synoptic::-webkit-scrollbar {
+	height: 0;
+	width: 0;
+}
+#synoptic {
+	scrollbar-width: none;
+}
+
+.tooltip-right,
+.tooltip-left,
+.tooltip-bottom,
+.tooltip-bottom-overflow-left,
+.tooltip-bottom-overflow-right {
 	visibility: hidden;
-    min-width: 180px;
-    max-width: 300px;
-    background-color: #555;
-    color: #fff;
-    text-align: center;
-    border-radius: 6px;
-    padding: 5px 0;
-    position: absolute;
-    opacity: 0;
-  	transition: opacity 0.5s;
-   
+	opacity: 0;
+	position: absolute;
+	min-width: 200px;
+	max-width: 320px;
+	padding: 10px 12px;
+	background: #1f2937;
+	color: #f9fafb;
+	border-radius: 6px;
+	box-shadow: 0 10px 25px -5px rgba(0, 0, 0, 0.25), 0 4px 10px -3px rgba(0, 0, 0, 0.15);
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+	font-size: 12px;
+	line-height: 1.45;
+	pointer-events: none;
+	transition: opacity 0.15s ease;
+	z-index: 20;
 }
-.tooltip-left::after{
+
+.tooltip-right::after,
+.tooltip-left::after,
+.tooltip-bottom::after,
+.tooltip-bottom-overflow-left::after,
+.tooltip-bottom-overflow-right::after {
 	content: "";
-    position: absolute;
-    top: 10px;
-    left: 100%; /* To the left of the tooltip */
-    border-width: 5px;
-    border-style: solid;
-    border-color: transparent  transparent  transparent #555;
+	position: absolute;
+	border: 6px solid transparent;
 }
 
-
-.tooltip-bottom{
-	visibility: hidden;
-    min-width: 180px;
-    max-width: 300px;
-    background-color: #555;
-    color: #fff;
-    text-align: center;
-    border-radius: 6px;
-    padding: 5px 0;
-    position: relative;
-    opacity: 0;
-  	transition: opacity 0.5s;
-   
+.tooltip-right::after {
+	top: 12px;
+	right: 100%;
+	border-right-color: #1f2937;
 }
 
-.tooltip-bottom-overflow-left{
-	visibility: hidden;
-    min-width: 180px;
-    max-width: 300px;
-    background-color: #555;
-    color: #fff;
-    text-align: center;
-    border-radius: 6px;
-    padding: 5px 0;
-    position: relative;
-    opacity: 0;
-  	transition: opacity 0.5s;
-   
-}
-.tooltip-bottom-overflow-right{
-	visibility: hidden;
-    min-width: 180px;
-    max-width: 300px;
-    background-color: #555;
-    color: #fff;
-    text-align: center;
-    border-radius: 6px;
-    padding: 5px 0;
-    position: relative;
-    opacity: 0;
-  	transition: opacity 0.5s;
-   
-}
-.tooltip-bottom::after{
-	content: "";
-    position: absolute;
-    left: 50%;
-    bottom: 100%; /* To the left of the tooltip */
-    margin-left: -5px;
-    border-width: 5px;
-    border-style: solid;
-    border-color:  transparent   transparent  #555 transparent;
+.tooltip-left::after {
+	top: 12px;
+	left: 100%;
+	border-left-color: #1f2937;
 }
 
-.tooltip-bottom-overflow-right::after{
-	content: "";
-    position: absolute;
-    left: 90%;
-    bottom: 100%; /* To the left of the tooltip */
-    margin-left: -5px;
-    border-width: 5px;
-    border-style: solid;
-    border-color:  transparent   transparent  #555 transparent;
+.tooltip-bottom::after {
+	left: 50%;
+	bottom: 100%;
+	margin-left: -6px;
+	border-bottom-color: #1f2937;
 }
 
-
-.tooltip-bottom-overflow-left::after{
-	content: "";
-    position: absolute;
-    left: 10%;
-    bottom: 100%; /* To the left of the tooltip */
-    margin-left: -5px;
-    border-width: 5px;
-    border-style: solid;
-    border-color:  transparent   transparent  #555 transparent;
-}
-.tooltip-right{
-	visibility: visible;
-     min-width: 180px;
-    max-width: 300px;
-    background-color: #555;
-    color: #fff;
-    text-align: center;
-    border-radius: 6px;
-    padding: 5px 0;
-    position: absolute;
-    opacity: 0;
-  	transition: opacity 0.5s;
-  
-   
+.tooltip-bottom-overflow-left::after {
+	left: 14%;
+	bottom: 100%;
+	margin-left: -6px;
+	border-bottom-color: #1f2937;
 }
 
-.tooltip-right::after{
-	content: " ";
-    position: absolute;
-    top: 10px;
-    right: 100%; /* To the left of the tooltip */
-    border-width: 5px;
-    border-style: solid;
-    border-color: transparent #555 transparent transparent;
+.tooltip-bottom-overflow-right::after {
+	right: 14%;
+	bottom: 100%;
+	margin-right: -6px;
+	border-bottom-color: #1f2937;
 }
 
-
-
-.tooltip-right .table{
+.synopticInfo {
+	width: 100%;
+	border-collapse: collapse;
+	color: #f9fafb;
 	text-align: left;
-    width: 100%;
-    background-color: #555;
-    color: #fff;
-    font-size:10px;
-    padding-left:3px;
-    padding-right:3px;
-    margin: 0 auto;
-}
-	
-.tooltipTable {
-	text-align: left;
-     width: 100%;
-    background-color: #555;
-    color: #fff;
-    font-size:10px;
-    padding-left:3px;
-    padding-right:3px;
-    margin: 0 auto;
-}
-	
-.tooltip-left .table{
-	text-align: left;
-      width: 100%;
-    background-color: #555;
-    color: #fff;
-    font-size:10px;
-    padding-left:3px;
-    padding-right:3px;
-    margin: 0 auto;
-}
-	
-.tooltip-bottom .table{
-	text-align: left;
-     width: 100%;
-    background-color: #555;
-    color: #fff;
-    font-size:8px;
-   
-    margin: 0 auto;
-}
-.synopticTitle
-{
-	 background-color: #555;
-	 color: #fff;
-	 font-size:10px;
-	 position: absolute;
-	 top:0;
-	 left:0;
-	 visibility: visible;
-	 width:100%
 }
 
-.menu {
-	visibility: visible;
-    width: 180px;
-    background-color: #555;
-    color: #fff;
-    text-align: center;
-    border-radius: 6px;
-    padding: 5px 0;
-    position: absolute;
+.synopticInfo caption {
+	caption-side: top;
+	padding-bottom: 6px;
+	margin-bottom: 6px;
+	border-bottom: 1px solid rgba(255, 255, 255, 0.15);
+	font-weight: 600;
+	font-size: 13px;
+	text-align: left;
 }
 
+.synopticInfo th,
+.synopticInfo td {
+	padding: 2px 0;
+	font-weight: normal;
+	vertical-align: top;
+}
+
+.synopticInfo th {
+	color: #9ca3af;
+	padding-right: 10px;
+	white-space: nowrap;
+}
+
+.synopticInfo td {
+	color: #f9fafb;
+}
+
+.synopticPredictions__title {
+	font-weight: 600;
+	font-size: 13px;
+	margin-bottom: 8px;
+	padding-bottom: 6px;
+	border-bottom: 1px solid rgba(255, 255, 255, 0.15);
+}
+
+.synopticPredictions__headsign {
+	color: #d1d5db;
+	font-size: 12px;
+	margin-top: 8px;
+	margin-bottom: 4px;
+}
+
+.synopticPredictions__headsign:first-of-type {
+	margin-top: 0;
+}
+
+.synopticPredictions__table {
+	width: 100%;
+	border-collapse: collapse;
+	color: #f9fafb;
+	font-size: 12px;
+	text-align: left;
+}
+
+.synopticPredictions__table th {
+	color: #9ca3af;
+	font-weight: 600;
+	padding: 4px 8px 4px 0;
+	border-bottom: 1px solid rgba(255, 255, 255, 0.15);
+}
+
+.synopticPredictions__table td {
+	padding: 3px 8px 3px 0;
+	border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.synopticPredictions__table tr:last-child td {
+	border-bottom: 0;
+}
+
+.synopticPredictions__table .num {
+	text-align: right;
+	font-variant-numeric: tabular-nums;
+	padding-right: 0;
+}
+
+.synopticPredictions__empty {
+	color: #9ca3af;
+	font-style: italic;
+	padding: 4px 0;
+}
+
+/* Sinoptico creates the context menu up front, so default to hidden —
+ * otherwise the empty menu paints a dark stripe before any right-click. */
+.menu,
 .menu-content {
-	visibility: visible;
-	width: 180px;
-   
-    position: absolute;
-    background-color: #555;
-  /*  box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2);*/
-    
+	visibility: hidden;
+	width: 160px;
+	padding: 4px 0;
+	background: #1f2937;
+	color: #f9fafb;
+	border-radius: 6px;
+	box-shadow: 0 10px 25px -5px rgba(0, 0, 0, 0.25);
+	position: absolute;
+	z-index: 25;
 }
 
 .menu-content a {
-    color: black;
-    padding: 3px 3px;
-    text-decoration: none;
-    font-size: 8px;
-    color: #fff;
-    display: block;
-}
-
-.menu-content a:hover {background-color: #777}
-
-.menu .menu-content {
-    
-}
-/*
-.menu-options {
-	list-style: none;
-	padding: 10px 0;
-}
-
-.menu-item {
-	font-weight: 500;
-	font-size: 14px;
-	padding: 10px 40px 10px 20px;
+	display: block;
+	padding: 6px 12px;
+	color: #f9fafb;
+	font-size: 12px;
+	text-decoration: none;
 	cursor: pointer;
 }
 
-.menu-item:hover {
-	background: rgba(0, 0, 0, 0.2);
-}*/
+.menu-content a:hover {
+	background: #374151;
+}
+
+/* Legacy in-canvas route name banner — hidden because the page header
+ * already shows the title and route. */
+.synopticTitle {
+	display: none;
+}

--- a/transitclockWebapp/src/main/webapp/synoptic/index.jsp
+++ b/transitclockWebapp/src/main/webapp/synoptic/index.jsp
@@ -1,3 +1,4 @@
+<%@ page pageEncoding="UTF-8" %>
 <%
 pageContext.setAttribute("ctx", request.getContextPath());
 %>
@@ -30,27 +31,20 @@ pageContext.setAttribute("ctx", request.getContextPath());
   <!-- Load in Select2 files so can create fancy selectors -->
   <link href="//cdnjs.cloudflare.com/ajax/libs/select2/4.0.0/css/select2.min.css" rel="stylesheet" />
   <script src="//cdnjs.cloudflare.com/ajax/libs/select2/4.0.0/js/select2.min.js"></script>
-
-
-  <!--  Override the body style from the includes.jsp/general.css files -->
-  <style>
-    body {
-	  margin: 0px;
-    }
-  </style>
   </jsp:attribute>
   <jsp:body>
-  <div id="routesContainer">
-    <div id="routesDiv">
-      <select id="routes" style="width:380px"></select>
-      <input type="hidden" id="routes" style="width:380px" />
-    </div>
+  <t:mapPage>
+    <jsp:attribute name="title"><fmt:message key="div.synoptic"/></jsp:attribute>
+    <jsp:attribute name="actions">
+      <div id="routesDiv" class="ml-auto">
+        <select id="routes" style="width:320px"></select>
+      </div>
+    </jsp:attribute>
+    <jsp:body>
+  <div id="synoptic"></div>
+  <div id="synopticScrollbar" aria-hidden="true">
+    <div id="synopticScrollThumb"></div>
   </div>
-  <!-- For testing purpose
-  <input type="button" onclick="myFunction()" value="test"/>
-  -->
-  <div id="synoptic"
-		style="width: 100%; height: 480px; left: 0px; top: 50px; position: absolute;' "></div>
 	<script type="text/javascript">
 
 	var agencyTimezoneOffset;
@@ -148,70 +142,36 @@ function predictionCallback(preds, status) {
 	var stopName = routeStopPreds.stopName;
 	if (routeStopPreds.stopCode)
 		stopName += " (" + routeStopPreds.stopCode + ")";
-	var content = '<table class="tooltipTable">'
-		+ '<tr><td><b>Stop:</b> ' + stopName + '</td></tr>';
-	//if (verbose)
-	//	content += '<b>Stop Id:</b> ' + routeStopPreds.stopId + '<br/>';
+	var content = '<div class="synopticPredictions">'
+		+ '<div class="synopticPredictions__title">' + stopName + '</div>';
 
-	// For each destination add predictions
 	for (var i in routeStopPreds.dest) {
-		// If there are several destinations then add a horizontal rule
-		// to break predictions up by destination
-		if (routeStopPreds.dest.length > 1)
-			content += '<tr><td>############</td></tr>';
+		var dest = routeStopPreds.dest[i];
+		if (dest.headsign)
+			content += '<div class="synopticPredictions__headsign">' + dest.headsign + '</div>';
 
-		// Add the destination/headsign info
-		if (routeStopPreds.dest[i].headsign)
-			content += '<tr><td><b>Destination:</b> ' + routeStopPreds.dest[i].headsign + '</td></tr>';
-		content +='<tr><td>';
-		// Add each prediction for the current destination
-
-		if (routeStopPreds.dest[i].pred.length > 0) {
-			content += '<table  class="tooltipTable" style="border-spacing: 0px;border-collapse: collapse;">';
-			content += '<tr class="tooltipTable" style="font-weight:bold;"><td style="border: 1px solid">trip</td>';
-			content += '<td style="border: 1px solid">Vehicle</td>';
-			content += '<td style="border: 1px solid">Minutes</td>';
-			for (var j in routeStopPreds.dest[i].pred) {
-				// Separators between the predictions
-
-
-				// Add the actual prediction
-				var pred = routeStopPreds.dest[i].pred[j];
-				content+= '<tr ><td style="border: 1px solid">'+  pred.trip + "</td>";
-				var ident=synoptic.getVehicleIdentifier(pred.vehicle );
-				if(ident==null)
-					ident=pred.vehicle;
-				content+= '<td style="border: 1px solid">'+ ident + "</td>";
-				content+= '<td style="border: 1px solid">'+  pred.min + "</td></tr>";
-
-
-				// Added any special indipredcators for if schedule based,
-				// delayed, or not yet departed from terminal
-				/*
-				if (pred.scheduleBased)
-					content += '<sup>sched</sup>';
-				else {
-					if (pred.notYetDeparted)
-						content += '<sup>not yet left</sup>';
-					else
-						if (pred.delayed)
-							content += '<sup>delayed</sup>';
-				}
-				*/
-				// If in verbose mode add vehicle info
-				//if (verbose)
+		if (dest.pred.length > 0) {
+			content += '<table class="synopticPredictions__table">'
+				+ '<thead><tr><th>Trip</th><th>Vehicle</th><th class="num">Min</th></tr></thead>'
+				+ '<tbody>';
+			for (var j in dest.pred) {
+				var pred = dest.pred[j];
+				var ident = synoptic.getVehicleIdentifier(pred.vehicle);
+				if (ident == null)
+					ident = pred.vehicle;
+				content += '<tr><td>' + pred.trip + '</td>'
+					+ '<td>' + ident + '</td>'
+					+ '<td class="num">' + pred.min + '</td></tr>';
 			}
 
-			content += '</table>';
+			content += '</tbody></table>';
 
 		} else {
-			// There are no predictions so let user know
-			content += "No predictions";
+			content += '<div class="synopticPredictions__empty">No predictions</div>';
 		}
-		content +='</td></tr>';
 	}
+	content += '</div>';
 
-	// Now update popup with the wonderful prediction info
 	synoptic.setPredictionsContent(content);
 }
 
@@ -315,10 +275,29 @@ function routeConfigCallback(routeDetail, status)
 	}
 	var params={container:canvas,
 			onVehiClick:testFunc,
-			infoStop:function(data) {console.log(data.identifier);return "<table class=\"table\"><th >"+data.identifier+"</th><tr><td>distance: "+parseFloat(data.distance).toFixed(2) +" m. </td></tr></table>"},
-			//var startTimeStr = vehicleData.isScheduledService ? "" : "<br/><b>Start Time:</b> "+dateFormat(vehicleData.freqStartTime/1000)
-			infoVehicle:function(data) {console.log(data.identifier);return "<table class=\"table\"><th >"+data.identifier+"</th><tr><td>GPSTime: "+data.gpsTimeStr +" </td></tr><tr><td>NextStop: "+data.nextStopName+"</td></tr><tr><td>schAdh: "+data.schAdhStr+"</td></tr><tr><td>trip: "+data.trip+((data.isScheduledService!=undefined && data.isScheduledService==false)?("</td></tr><tr><td>Start Time: "+dateFormat(data.freqStartTime/1000)):"")+"</td></tr><tr><td>headway: "+((data.headway==-1)?"-":((data.headway/60000).toFixed(2))+ " min.") +"</td><tr></table>"},
-			routeName:routeDetail.routes[0].name,
+			infoStop:function(data) {
+				return '<table class="synopticInfo">'
+					+ '<caption>'+data.identifier+'</caption>'
+					+ '<tr><th scope="row">Distance</th><td>'+parseFloat(data.distance).toFixed(2)+' m</td></tr>'
+					+ '</table>';
+			},
+			infoVehicle:function(data) {
+				var startTimeRow = (data.isScheduledService==false)
+					? '<tr><th scope="row">Start time</th><td>'+dateFormat(data.freqStartTime/1000)+'</td></tr>'
+					: '';
+				var headwayValue = (data.headway==-1)
+					? '—'
+					: (data.headway/60000).toFixed(2)+' min';
+				return '<table class="synopticInfo">'
+					+ '<caption>Bus '+data.identifier+'</caption>'
+					+ '<tr><th scope="row">GPS time</th><td>'+data.gpsTimeStr+'</td></tr>'
+					+ '<tr><th scope="row">Next stop</th><td>'+data.nextStopName+'</td></tr>'
+					+ '<tr><th scope="row">Sched adh</th><td>'+data.schAdhStr+'</td></tr>'
+					+ '<tr><th scope="row">Trip</th><td>'+data.trip+'</td></tr>'
+					+ startTimeRow
+					+ '<tr><th scope="row">Headway</th><td>'+headwayValue+'</td></tr>'
+					+ '</table>';
+			},
 			patternType:routeDetail.routes[0].shape[0].patternType,
 			drawReturnUpside:false,
 			showReturn:showReturn,
@@ -388,5 +367,7 @@ function routeConfigCallback(routeDetail, status)
 	 	});
 
 	</script>
+    </jsp:body>
+  </t:mapPage>
   </jsp:body>
 </t:layout>

--- a/transitclockWebapp/src/main/webapp/synoptic/index.jsp
+++ b/transitclockWebapp/src/main/webapp/synoptic/index.jsp
@@ -198,7 +198,7 @@ function vehicleUpdate(vehicleDetail, status)
 		var directionVehicle=(vehicle.direction=="0" || vehicle.direction==undefined)?0:1;
 		var _identifier=(vehicle.licensePlate==undefined)?vehicle.id:vehicle.licensePlate;
 		var gpsTimeStr = dateFormat(vehicle.loc.time);
-		buses.push({id:vehicle.id, projection:vehicle.distanceAlongTrip/getShapeLength(vehicle.tripPattern),identifier:_identifier,direction:directionVehicle,gpsTimeStr:gpsTimeStr,nextStopName:vehicle.nextStopName,schAdhStr:vehicle.schAdhStr,trip:vehicle.trip,schAdh:vehicle.schAdh,headway:vehicle.headway});
+		buses.push({id:vehicle.id, projection:vehicle.distanceAlongTrip/getShapeLength(vehicle.tripPattern),identifier:_identifier,direction:directionVehicle,gpsTimeStr:gpsTimeStr,nextStopName:vehicle.nextStopName,schAdhStr:vehicle.schAdhStr,trip:vehicle.trip,schAdh:vehicle.schAdh,headway:vehicle.headway,isScheduledService:vehicle.isScheduledService,freqStartTime:vehicle.freqStartTime});
 
 	}
 	synoptic.setBuses(buses);

--- a/transitclockWebapp/src/main/webapp/synoptic/javascript/synoptic.js
+++ b/transitclockWebapp/src/main/webapp/synoptic/javascript/synoptic.js
@@ -665,27 +665,26 @@ class Sinoptico
 		var thumb=document.getElementById('synopticScrollThumb');
 		if(!bar || !thumb)
 			return;
-		// Sinoptico is reconstructed on every route selection, so wire each
-		// instance to its own thumb/track.
+		// `init()` runs for every route selection but the scrollbar nodes live
+		// outside the canvas and survive — tear down the previous instance's
+		// listeners so we don't stack handlers and leak old Sinoptico instances.
+		Sinoptico.__teardownScrollIndicator(bar, thumb);
+
 		this.scrollBar=bar;
 		this.scrollThumb=thumb;
-
 		var self=this;
 		var dragStartX=0;
 		var dragStartScrollLeft=0;
 
-		this.container.addEventListener('scroll',function(){
-			self.__updateScrollIndicator();
-		});
-
-		thumb.addEventListener('pointerdown',function(e){
+		var onScroll=function(){ self.__updateScrollIndicator(); };
+		var onThumbDown=function(e){
 			e.preventDefault();
 			thumb.setPointerCapture(e.pointerId);
 			thumb.classList.add('dragging');
 			dragStartX=e.clientX;
 			dragStartScrollLeft=self.container.scrollLeft;
-		});
-		thumb.addEventListener('pointermove',function(e){
+		};
+		var onThumbMove=function(e){
 			if(!thumb.hasPointerCapture(e.pointerId))
 				return;
 			var maxScrollLeft=self.container.scrollWidth-self.container.clientWidth;
@@ -694,13 +693,13 @@ class Sinoptico
 				return;
 			var deltaX=e.clientX-dragStartX;
 			self.container.scrollLeft=dragStartScrollLeft+deltaX*(maxScrollLeft/maxThumbLeft);
-		});
-		thumb.addEventListener('pointerup',function(e){
-			thumb.releasePointerCapture(e.pointerId);
+		};
+		var endDrag=function(e){
+			if(thumb.hasPointerCapture(e.pointerId))
+				thumb.releasePointerCapture(e.pointerId);
 			thumb.classList.remove('dragging');
-		});
-
-		bar.addEventListener('pointerdown',function(e){
+		};
+		var onBarDown=function(e){
 			if(e.target===thumb)
 				return;
 			var maxScrollLeft=self.container.scrollWidth-self.container.clientWidth;
@@ -709,7 +708,38 @@ class Sinoptico
 				return;
 			var clickX=e.clientX-bar.getBoundingClientRect().left-thumb.clientWidth/2;
 			self.container.scrollLeft=(clickX/maxThumbLeft)*maxScrollLeft;
-		});
+		};
+
+		this.container.addEventListener('scroll',onScroll);
+		thumb.addEventListener('pointerdown',onThumbDown);
+		thumb.addEventListener('pointermove',onThumbMove);
+		thumb.addEventListener('pointerup',endDrag);
+		thumb.addEventListener('pointercancel',endDrag);
+		bar.addEventListener('pointerdown',onBarDown);
+
+		// Keep the un-binders attached to the DOM nodes so the next Sinoptico
+		// can find and remove them without inheriting our state.
+		bar.__synopticTeardown={
+			container:this.container,
+			onScroll:onScroll,
+			onThumbDown:onThumbDown,
+			onThumbMove:onThumbMove,
+			endDrag:endDrag,
+			onBarDown:onBarDown
+		};
+	}
+	static __teardownScrollIndicator(bar, thumb)
+	{
+		var prev=bar.__synopticTeardown;
+		if(!prev)
+			return;
+		prev.container.removeEventListener('scroll',prev.onScroll);
+		thumb.removeEventListener('pointerdown',prev.onThumbDown);
+		thumb.removeEventListener('pointermove',prev.onThumbMove);
+		thumb.removeEventListener('pointerup',prev.endDrag);
+		thumb.removeEventListener('pointercancel',prev.endDrag);
+		bar.removeEventListener('pointerdown',prev.onBarDown);
+		bar.__synopticTeardown=null;
 	}
 	getLastPostition(id)
 	{

--- a/transitclockWebapp/src/main/webapp/synoptic/javascript/synoptic.js
+++ b/transitclockWebapp/src/main/webapp/synoptic/javascript/synoptic.js
@@ -155,6 +155,7 @@ class Sinoptico
 		this.stopImg.onload = this.resize;
 		//It has to be here for the first time it loads the image.
 		this.stopImg.src = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEwAACxMBAJqcGAAAAPVJREFUOI2Vkl1qwlAQhT/z1GQpNYRQ29XUJYkiqOiDS7GldBENFUSx\ne2jjy/XhnluHGPJzYEgyOTNz5gfu8QRsgD1wkX0DayCv4f8jAbaAa7ENENcFf4rwC0yk5EE2AqbA\nnzgf1SSh8gl4bFCZAmdx17bnULkp2CYpFZOjnpxkd8VMMSvw03ZSYlEdnsWzfAX4NTn8sLomSOQr\nox6yaxEBR70Pe8QF7iEC3vTxWiENKmYx1nMHfhUOfyRph+oZtzVmwRlWeW5JkgE/4i7tjxh/nkHJ\nDL+qRPYCzE3ld+63RmyUNNmyLtgix19YoYol8AUsbM8BV0fAV591YB1RAAAAAElFTkSuQmCC\n';
+		this.__bindScrollIndicator();
 		this.resize();
 	}
 	getVehicleIdentifier(id)
@@ -613,8 +614,10 @@ class Sinoptico
 			width=this.container.clientWidth;
 			height=this.container.clientHeight
 		}
-		width=this.zoomFactor*width;
-		this.container.style.overflow="auto";  
+		var minPxPerStop=80;
+		var stopCount=(this.stops!=undefined && this.stops!=null)?this.stops.length:0;
+		var minContentWidth=Math.max(width, stopCount*minPxPerStop+2*this.margin);
+		width=this.zoomFactor*minContentWidth;
 		//console.log(this.canvas.style);
 		if(this.canvas.border!= undefined)
 		{
@@ -629,7 +632,84 @@ class Sinoptico
 		this.canvas.width = width;
 		this.canvas.height = height;
 		this.paint();
+		this.__updateScrollIndicator();
 		this.resized=true;
+	}
+	__updateScrollIndicator()
+	{
+		var bar=this.scrollBar;
+		var thumb=this.scrollThumb;
+		if(!bar || !thumb)
+			return;
+		var scrollWidth=this.container.scrollWidth;
+		var clientWidth=this.container.clientWidth;
+		if(scrollWidth<=clientWidth)
+		{
+			bar.style.display='none';
+			return;
+		}
+		bar.style.display='block';
+		var trackWidth=bar.clientWidth;
+		var thumbWidth=Math.max(40, trackWidth*clientWidth/scrollWidth);
+		var maxThumbLeft=trackWidth-thumbWidth;
+		var maxScrollLeft=scrollWidth-clientWidth;
+		var thumbLeft=maxScrollLeft>0
+			? (this.container.scrollLeft/maxScrollLeft)*maxThumbLeft
+			: 0;
+		thumb.style.width=thumbWidth+'px';
+		thumb.style.left=thumbLeft+'px';
+	}
+	__bindScrollIndicator()
+	{
+		var bar=document.getElementById('synopticScrollbar');
+		var thumb=document.getElementById('synopticScrollThumb');
+		if(!bar || !thumb)
+			return;
+		// Sinoptico is reconstructed on every route selection, so wire each
+		// instance to its own thumb/track.
+		this.scrollBar=bar;
+		this.scrollThumb=thumb;
+
+		var self=this;
+		var dragStartX=0;
+		var dragStartScrollLeft=0;
+
+		this.container.addEventListener('scroll',function(){
+			self.__updateScrollIndicator();
+		});
+
+		thumb.addEventListener('pointerdown',function(e){
+			e.preventDefault();
+			thumb.setPointerCapture(e.pointerId);
+			thumb.classList.add('dragging');
+			dragStartX=e.clientX;
+			dragStartScrollLeft=self.container.scrollLeft;
+		});
+		thumb.addEventListener('pointermove',function(e){
+			if(!thumb.hasPointerCapture(e.pointerId))
+				return;
+			var maxScrollLeft=self.container.scrollWidth-self.container.clientWidth;
+			var maxThumbLeft=bar.clientWidth-thumb.clientWidth;
+			if(maxThumbLeft<=0)
+				return;
+			var deltaX=e.clientX-dragStartX;
+			self.container.scrollLeft=dragStartScrollLeft+deltaX*(maxScrollLeft/maxThumbLeft);
+		});
+		thumb.addEventListener('pointerup',function(e){
+			thumb.releasePointerCapture(e.pointerId);
+			thumb.classList.remove('dragging');
+		});
+
+		bar.addEventListener('pointerdown',function(e){
+			if(e.target===thumb)
+				return;
+			var maxScrollLeft=self.container.scrollWidth-self.container.clientWidth;
+			var maxThumbLeft=bar.clientWidth-thumb.clientWidth;
+			if(maxThumbLeft<=0)
+				return;
+			var clickX=e.clientX-bar.getBoundingClientRect().left-thumb.clientWidth/2;
+			self.container.scrollLeft=(clickX/maxThumbLeft)*maxScrollLeft;
+		});
 	}
 	getLastPostition(id)
 	{


### PR DESCRIPTION
## Summary
- Wrap `synoptic/index.jsp` in `<t:mapPage>` so the canvas fits in `<main>` instead of absolutely positioning over the sidebar; route picker moves into the header's actions slot.
- Add an always-visible custom horizontal scrollbar (`#synopticScrollbar` + `Sinoptico.__bindScrollIndicator`) driven by pointer capture so macOS overlay scrollbars don't auto-hide and there are no document-level listeners that leak across route changes.
- Restyle bus/stop/prediction tooltips as a dark info card, drop the dead `############` separator and the buggy `.menu-content { visibility: visible }` default that painted a stripe before any right-click.

## Test plan
- [x] Loaded the page with no route selected — clean header bar, no scrollbar visible.
- [x] Selected route A1X — synoptic line renders inside the main pane, gray scrollbar appears at the bottom with a thumb sized to the viewport.
- [x] Set `scrollLeft` programmatically — thumb tracks the scroll position.
- [x] Hovered a bus marker — dark tooltip card with aligned label/value pairs and an em-dash for empty headway (UTF-8 page encoding declared on the JSP so multi-byte chars survive Tomcat's default ISO-8859-1 read).

## Review notes
- Pre-existing leak: `Sinoptico.init()` registers a `window.resize` listener via `this.resize` that's never removed when a new route swaps in a fresh Sinoptico. Out of scope for this PR; flagging for a follow-up.
- The select2 route-picker bootstrap is now near-identical between `synoptic/index.jsp` and `maps/map.jsp` (selector data load + `.select2(...)` + `select2:select` + the "disable container tooltip" hack). A shared `<t:routePicker>` tag would dedupe both — leaving for a separate refactor.
- Tooltip builders (`infoVehicle`, `infoStop`, `predictionCallback`) still string-concatenate fields without missing-value guards — a missing `freqStartTime` or `nextStopName` would render as `undefined` / `NaN`. Pre-existing, didn't introduce; worth fixing alongside an end-to-end test of the API contract.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Custom horizontal scrollbar with draggable thumb for improved navigation

* **Style**
  * Redesigned tooltip system with unified sizing, dark theme, transitions, and arrow handling
  * Restyled context menu (hidden by default) and updated hover/size behavior
  * New table and layout styles for info and prediction popups; legacy banner removed

* **Bug Fixes**
  * Improved resize/scroll behavior and removed noisy console output; prevented duplicate event handlers
<!-- end of auto-generated comment: release notes by coderabbit.ai -->