### PR TITLE
Redesign chrome and Active Blocks page around the OneBusAway look

### DIFF
--- a/transitclockWebapp/frontend/tailwind.css
+++ b/transitclockWebapp/frontend/tailwind.css
@@ -5,3 +5,20 @@
 @source "../src/main/webapp/**/*.html";
 @source "../src/main/webapp/**/*.js";
 @source "../frontend/**/*.js";
+
+/* OneBusAway brand tokens. Source of truth: the OneBusAway design
+   package (separate repo) at project/assets/colors_and_type.css
+   (#78aa36 brand, #486621 accent). The status palette mirrors what
+   Wayfinder's ArrivalDeparture component uses (red = early, green =
+   on time, violet = late, blue = scheduled-only). */
+@theme {
+  --color-brand: #78aa36;
+  --color-brand-accent: #486621;
+  --color-brand-tint: #f0f5e6;
+  --color-canvas: #f5f6f3;
+  --color-status-on-time: #22c55e;
+  --color-status-on-time-ink: #15803d;
+  --color-status-early: #ef4444;
+  --color-status-late: #7c3aed;
+  --color-status-scheduled: #3b82f6;
+}

--- a/transitclockWebapp/src/main/resources/org/transitclock/i18n/text.properties
+++ b/transitclockWebapp/src/main/resources/org/transitclock/i18n/text.properties
@@ -201,4 +201,6 @@ div.Headsign = Headsign
 div.Start = Start:
 div.End = End:
 div.Service = Service:
+div.Schedule = Schedule
+div.operations = Operations
 div.loading = Loading...

--- a/transitclockWebapp/src/main/webapp/WEB-INF/tags/layout.tag
+++ b/transitclockWebapp/src/main/webapp/WEB-INF/tags/layout.tag
@@ -12,6 +12,14 @@
 <% jspContext.setAttribute("webAgencies", WebAgency.getCachedOrderedListOfWebAgencies()); %>
 <fmt:setLocale value="${pageContext.request.locale}" />
 
+<%-- currentAgency may be empty (e.g. welcome page) — the brand bar
+     renders product-name-only in that case. --%>
+<c:forEach var="agency" items="${webAgencies}">
+  <c:if test="${agency.active and agency.agencyId == param.a}">
+    <c:set var="currentAgency" value="${agency}"/>
+  </c:if>
+</c:forEach>
+
 <%-- Sidebar selection state. The on* flags identify the current page from
      the request path/query; the agency-scoped *Active flags are computed
      inside the per-agency forEach below so only the active agency's group
@@ -29,25 +37,55 @@
 <c:set var="onServerStatus" value="${path == '/status/serverStatus.jsp'}"/>
 <c:set var="onDbDiskSpace"  value="${path == '/status/dbDiskSpace.jsp'}"/>
 <c:set var="onSynoptic"     value="${path == '/synoptic/index.jsp'}"/>
-<c:set var="topActive"      value="bg-gray-100 text-gray-900 font-medium"/>
-<c:set var="topInactive"    value="text-gray-700 hover:bg-gray-100 hover:text-gray-900"/>
-<c:set var="subActive"      value="bg-gray-100 text-gray-900 font-medium"/>
-<c:set var="subInactive"    value="text-gray-600 hover:bg-gray-100 hover:text-gray-900"/>
+<%-- The left-edge pill on active items is an absolutely-positioned span
+     inside each link, which is why every link uses `relative`. --%>
+<c:set var="navBase"     value="relative flex items-center gap-2.5 px-2.5 py-1.5 rounded-md text-sm transition-colors"/>
+<c:set var="navInactive" value="text-gray-700 hover:bg-gray-100 hover:text-gray-900"/>
+<c:set var="navActive"   value="bg-brand-tint text-brand-accent font-semibold"/>
+<c:set var="iconActive"  value="text-brand-accent"/>
+<c:set var="iconIdle"    value="text-gray-500"/>
 
 <!DOCTYPE html>
-<html class="h-full bg-white">
+<html class="h-full">
 <head>
 <title>${title}</title>
 <%@ include file="/template/includes.jsp" %>
 <jsp:invoke fragment="head"/>
 </head>
-<body class="h-full">
-<div class="flex h-full">
-  <aside class="hidden md:flex md:flex-col w-64 shrink-0 border-r border-gray-200 bg-white">
-    <div class="flex items-center h-16 px-6 border-b border-gray-200">
-      <a href="${pageContext.request.contextPath}/" class="text-base font-semibold text-gray-900">The Transit Clock</a>
+<body class="h-full overflow-hidden flex flex-col bg-canvas">
+
+<header class="shrink-0 flex items-center justify-between h-14 px-6 bg-brand text-white border-b border-black/10 z-30">
+  <a href="${pageContext.request.contextPath}/" class="flex items-center gap-3.5 text-white no-underline">
+    <span class="size-9 rounded-md bg-white flex items-center justify-center shadow-[0_0_0_1px_rgba(255,255,255,0.2)]">
+      <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#78aa36" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <rect x="4" y="4" width="16" height="14" rx="2"/>
+        <path d="M4 11h16M7 18v2M17 18v2M9 15h.01M15 15h.01"/>
+      </svg>
+    </span>
+    <span class="flex items-center gap-2.5">
+      <c:choose>
+        <c:when test="${not empty currentAgency}">
+          <span class="text-lg font-extrabold tracking-tight"><c:out value="${fn:toUpperCase(currentAgency.agencyName)}"/></span>
+          <span class="opacity-55 text-sm">·</span>
+          <span class="text-sm font-medium opacity-95">The Transit Clock</span>
+        </c:when>
+        <c:otherwise>
+          <span class="text-lg font-extrabold tracking-tight">The Transit Clock</span>
+        </c:otherwise>
+      </c:choose>
+    </span>
+  </a>
+  <div class="flex items-center gap-3 text-sm">
+    <div class="flex items-center gap-2 px-2.5 py-1.5 rounded-md bg-white/15 font-semibold tabular-nums">
+      <span class="size-1.5 rounded-full bg-emerald-300 ring-2 ring-emerald-300/30" aria-hidden="true"></span>
+      <span>Live · <span data-tc-clock>--:--:-- --</span></span>
     </div>
-    <nav class="flex-1 overflow-y-auto px-3 py-4 space-y-6">
+  </div>
+</header>
+
+<div class="flex flex-1 min-h-0">
+  <aside class="hidden md:flex md:flex-col w-60 shrink-0 border-r border-gray-200 bg-white">
+    <nav class="flex-1 overflow-y-auto px-3 py-5 space-y-5">
       <c:forEach var="agency" items="${webAgencies}">
         <c:if test="${agency.active}">
           <c:set var="qs" value="?a=${agency.agencyId}"/>
@@ -62,58 +100,130 @@
           <c:set var="activeBlocksActive" value="${onActiveBlocks and agencyMatch}"/>
           <c:set var="serverStatusActive" value="${onServerStatus and agencyMatch}"/>
           <c:set var="dbDiskSpaceActive"  value="${onDbDiskSpace and agencyMatch}"/>
-          <c:set var="statusExpanded"     value="${activeBlocksActive or serverStatusActive or dbDiskSpaceActive}"/>
           <c:set var="synopticActive"     value="${onSynoptic and agencyMatch}"/>
+
           <div>
-            <h3 class="px-2 mb-1 text-xs font-semibold text-gray-500 uppercase tracking-wider">
-              <c:out value="${agency.agencyName}"/>
-            </h3>
+            <h3 class="px-2.5 mb-2 text-[11px] font-bold tracking-[0.08em] uppercase text-gray-500"><c:out value="${agency.agencyName}"/></h3>
             <ul class="space-y-0.5">
               <li data-controller="disclosure">
                 <button type="button" aria-expanded="${mapsExpanded}"
                         data-action="click->disclosure#toggle"
-                        class="w-full flex items-center justify-between px-2 py-1.5 text-sm text-gray-700 rounded hover:bg-gray-100 hover:text-gray-900">
-                  <span><fmt:message key="div.maps"/></span>
-                  <svg data-disclosure-target="chevron" class="w-3 h-3 text-gray-400 transition-transform ${mapsExpanded ? 'rotate-90' : ''}" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                        class="w-full ${navBase} ${navInactive} justify-between">
+                  <span class="flex items-center gap-2.5">
+                    <svg class="size-4 ${iconIdle}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M9 4 3 6v14l6-2 6 2 6-2V4l-6 2-6-2zM9 4v14M15 6v14"/></svg>
+                    <fmt:message key="div.maps"/>
+                  </span>
+                  <svg data-disclosure-target="chevron" class="size-3 text-gray-400 transition-transform ${mapsExpanded ? 'rotate-90' : ''}" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
                     <path fill-rule="evenodd" d="M7.21 14.77a.75.75 0 01.02-1.06L11.168 10 7.23 6.29a.75.75 0 111.04-1.08l4.5 4.25a.75.75 0 010 1.08l-4.5 4.25a.75.75 0 01-1.06-.02z" clip-rule="evenodd"/>
                   </svg>
                 </button>
-                <ul data-disclosure-target="panel" class="${mapsExpanded ? '' : 'hidden'} mt-1 ml-3 space-y-0.5">
-                  <li><a class="block px-2 py-1 text-sm rounded ${mapForActive ? subActive : subInactive}" <c:if test="${mapForActive}">aria-current="page"</c:if> href="${ctx}/maps/map.jsp${qs}&verbose=true"><fmt:message key="div.mapfor"/></a></li>
-                  <li><a class="block px-2 py-1 text-sm rounded ${mapInclActive ? subActive : subInactive}" <c:if test="${mapInclActive}">aria-current="page"</c:if> href="${ctx}/maps/map.jsp${qs}&verbose=true&showUnassignedVehicles=true"><fmt:message key="div.mapincluding"/></a></li>
-                  <li><a class="block px-2 py-1 text-sm rounded ${schAdhMapActive ? subActive : subInactive}" <c:if test="${schAdhMapActive}">aria-current="page"</c:if> href="${ctx}/maps/schAdhMap.jsp${qs}"><fmt:message key="div.ScheduleAdherenceMap"/></a></li>
+                <ul data-disclosure-target="panel" class="${mapsExpanded ? '' : 'hidden'} mt-1 ml-7 space-y-0.5">
+                  <li>
+                    <a class="${navBase} ${mapForActive ? navActive : navInactive}" <c:if test="${mapForActive}">aria-current="page"</c:if> href="${ctx}/maps/map.jsp${qs}&verbose=true">
+                      <c:if test="${mapForActive}"><span class="absolute left-0 top-1.5 bottom-1.5 w-[3px] rounded-r-sm bg-brand-accent"></span></c:if>
+                      <fmt:message key="div.mapfor"/>
+                    </a>
+                  </li>
+                  <li>
+                    <a class="${navBase} ${mapInclActive ? navActive : navInactive}" <c:if test="${mapInclActive}">aria-current="page"</c:if> href="${ctx}/maps/map.jsp${qs}&verbose=true&showUnassignedVehicles=true">
+                      <c:if test="${mapInclActive}"><span class="absolute left-0 top-1.5 bottom-1.5 w-[3px] rounded-r-sm bg-brand-accent"></span></c:if>
+                      <fmt:message key="div.mapincluding"/>
+                    </a>
+                  </li>
+                  <li>
+                    <a class="${navBase} ${schAdhMapActive ? navActive : navInactive}" <c:if test="${schAdhMapActive}">aria-current="page"</c:if> href="${ctx}/maps/schAdhMap.jsp${qs}">
+                      <c:if test="${schAdhMapActive}"><span class="absolute left-0 top-1.5 bottom-1.5 w-[3px] rounded-r-sm bg-brand-accent"></span></c:if>
+                      <fmt:message key="div.ScheduleAdherenceMap"/>
+                    </a>
+                  </li>
                 </ul>
               </li>
-              <li><a class="block px-2 py-1.5 text-sm rounded ${reportsActive ? topActive : topInactive}" <c:if test="${reportsActive}">aria-current="page"</c:if> href="${ctx}/reports/index.jsp${qs}"><fmt:message key="div.reports"/></a></li>
-              <li><a class="block px-2 py-1.5 text-sm rounded ${apiActive ? topActive : topInactive}" <c:if test="${apiActive}">aria-current="page"</c:if> href="${ctx}/reports/apiCalls/index.jsp${qs}"><fmt:message key="div.api"/></a></li>
-              <li data-controller="disclosure">
-                <button type="button" aria-expanded="${statusExpanded}"
-                        data-action="click->disclosure#toggle"
-                        class="w-full flex items-center justify-between px-2 py-1.5 text-sm text-gray-700 rounded hover:bg-gray-100 hover:text-gray-900">
-                  <span><fmt:message key="div.status"/></span>
-                  <svg data-disclosure-target="chevron" class="w-3 h-3 text-gray-400 transition-transform ${statusExpanded ? 'rotate-90' : ''}" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-                    <path fill-rule="evenodd" d="M7.21 14.77a.75.75 0 01.02-1.06L11.168 10 7.23 6.29a.75.75 0 111.04-1.08l4.5 4.25a.75.75 0 010 1.08l-4.5 4.25a.75.75 0 01-1.06-.02z" clip-rule="evenodd"/>
-                  </svg>
-                </button>
-                <ul data-disclosure-target="panel" class="${statusExpanded ? '' : 'hidden'} mt-1 ml-3 space-y-0.5">
-                  <li><a class="block px-2 py-1 text-sm rounded ${activeBlocksActive ? subActive : subInactive}" <c:if test="${activeBlocksActive}">aria-current="page"</c:if> href="${ctx}/status/activeBlocks.jsp${qs}"><fmt:message key="div.acbiveblock"/></a></li>
-                  <li><a class="block px-2 py-1 text-sm rounded ${serverStatusActive ? subActive : subInactive}" <c:if test="${serverStatusActive}">aria-current="page"</c:if> href="${ctx}/status/serverStatus.jsp${qs}"><fmt:message key="div.ss"/></a></li>
-                  <li><a class="block px-2 py-1 text-sm rounded ${dbDiskSpaceActive ? subActive : subInactive}" <c:if test="${dbDiskSpaceActive}">aria-current="page"</c:if> href="${ctx}/status/dbDiskSpace.jsp${qs}"><fmt:message key="div.ddsu"/></a></li>
-                </ul>
+              <li>
+                <a class="${navBase} ${reportsActive ? navActive : navInactive}" <c:if test="${reportsActive}">aria-current="page"</c:if> href="${ctx}/reports/index.jsp${qs}">
+                  <c:if test="${reportsActive}"><span class="absolute left-0 top-1.5 bottom-1.5 w-[3px] rounded-r-sm bg-brand-accent"></span></c:if>
+                  <svg class="size-4 ${reportsActive ? iconActive : iconIdle}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M3 21h18M5 21V10m6 11V5m6 16v-8"/></svg>
+                  <fmt:message key="div.reports"/>
+                </a>
               </li>
-              <li><a class="block px-2 py-1.5 text-sm rounded ${synopticActive ? topActive : topInactive}" <c:if test="${synopticActive}">aria-current="page"</c:if> href="${ctx}/synoptic/index.jsp${qs}"><fmt:message key="div.synoptic"/></a></li>
+              <li>
+                <a class="${navBase} ${apiActive ? navActive : navInactive}" <c:if test="${apiActive}">aria-current="page"</c:if> href="${ctx}/reports/apiCalls/index.jsp${qs}">
+                  <c:if test="${apiActive}"><span class="absolute left-0 top-1.5 bottom-1.5 w-[3px] rounded-r-sm bg-brand-accent"></span></c:if>
+                  <svg class="size-4 ${apiActive ? iconActive : iconIdle}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m8 8-5 4 5 4M16 8l5 4-5 4M14 4l-4 16"/></svg>
+                  <fmt:message key="div.api"/>
+                </a>
+              </li>
+            </ul>
+          </div>
+
+          <div>
+            <h3 class="px-2.5 mb-2 text-[11px] font-bold tracking-[0.08em] uppercase text-gray-500"><fmt:message key="div.status"/></h3>
+            <ul class="space-y-0.5">
+              <li>
+                <a class="${navBase} ${activeBlocksActive ? navActive : navInactive}" <c:if test="${activeBlocksActive}">aria-current="page"</c:if> href="${ctx}/status/activeBlocks.jsp${qs}">
+                  <c:if test="${activeBlocksActive}"><span class="absolute left-0 top-1.5 bottom-1.5 w-[3px] rounded-r-sm bg-brand-accent"></span></c:if>
+                  <svg class="size-4 ${activeBlocksActive ? iconActive : iconIdle}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="4" y="4" width="16" height="14" rx="2"/><path d="M4 11h16M7 18v2M17 18v2M9 15h.01M15 15h.01"/></svg>
+                  <fmt:message key="div.acbiveblock"/>
+                </a>
+              </li>
+              <li>
+                <a class="${navBase} ${serverStatusActive ? navActive : navInactive}" <c:if test="${serverStatusActive}">aria-current="page"</c:if> href="${ctx}/status/serverStatus.jsp${qs}">
+                  <c:if test="${serverStatusActive}"><span class="absolute left-0 top-1.5 bottom-1.5 w-[3px] rounded-r-sm bg-brand-accent"></span></c:if>
+                  <svg class="size-4 ${serverStatusActive ? iconActive : iconIdle}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="4" width="18" height="7" rx="1"/><rect x="3" y="13" width="18" height="7" rx="1"/><path d="M7 7.5h.01M7 16.5h.01"/></svg>
+                  <fmt:message key="div.ss"/>
+                </a>
+              </li>
+              <li>
+                <a class="${navBase} ${dbDiskSpaceActive ? navActive : navInactive}" <c:if test="${dbDiskSpaceActive}">aria-current="page"</c:if> href="${ctx}/status/dbDiskSpace.jsp${qs}">
+                  <c:if test="${dbDiskSpaceActive}"><span class="absolute left-0 top-1.5 bottom-1.5 w-[3px] rounded-r-sm bg-brand-accent"></span></c:if>
+                  <svg class="size-4 ${dbDiskSpaceActive ? iconActive : iconIdle}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><ellipse cx="12" cy="6" rx="8" ry="3"/><path d="M4 6v12c0 1.7 3.6 3 8 3s8-1.3 8-3V6M4 12c0 1.7 3.6 3 8 3s8-1.3 8-3"/></svg>
+                  <fmt:message key="div.ddsu"/>
+                </a>
+              </li>
+            </ul>
+          </div>
+
+          <div>
+            <h3 class="px-2.5 mb-2 text-[11px] font-bold tracking-[0.08em] uppercase text-gray-500"><fmt:message key="div.operations"/></h3>
+            <ul class="space-y-0.5">
+              <li>
+                <a class="${navBase} ${synopticActive ? navActive : navInactive}" <c:if test="${synopticActive}">aria-current="page"</c:if> href="${ctx}/synoptic/index.jsp${qs}">
+                  <c:if test="${synopticActive}"><span class="absolute left-0 top-1.5 bottom-1.5 w-[3px] rounded-r-sm bg-brand-accent"></span></c:if>
+                  <svg class="size-4 ${synopticActive ? iconActive : iconIdle}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>
+                  <fmt:message key="div.synoptic"/>
+                </a>
+              </li>
             </ul>
           </div>
         </c:if>
       </c:forEach>
     </nav>
   </aside>
-  <main class="flex-1 overflow-y-auto">
+  <main class="flex-1 min-w-0 overflow-y-auto">
     <c:choose>
       <c:when test="${bare}"><jsp:doBody/></c:when>
       <c:otherwise><div class="p-8"><jsp:doBody/></div></c:otherwise>
     </c:choose>
   </main>
 </div>
+
+<%-- Inlined because it's tiny and only one page-global element needs it;
+     not worth a separate Stimulus controller. --%>
+<script>
+(function () {
+  var el = document.querySelector('[data-tc-clock]');
+  if (!el) return;
+  var pad = function (n) { return String(n).padStart(2, '0'); };
+  var tick = function () {
+    var d = new Date();
+    var h = d.getHours();
+    var ampm = h >= 12 ? 'PM' : 'AM';
+    h = h % 12 || 12;
+    el.textContent = pad(h) + ':' + pad(d.getMinutes()) + ':' + pad(d.getSeconds()) + ' ' + ampm;
+  };
+  tick();
+  setInterval(tick, 1000);
+})();
+</script>
+
 </body>
 </html>

--- a/transitclockWebapp/src/main/webapp/css/general.css
+++ b/transitclockWebapp/src/main/webapp/css/general.css
@@ -8,23 +8,6 @@ body {
 	margin: 0px 0px 10px 0px;
 }
 
-/* For the header on each page */
-#header {
-    background: linear-gradient(to right, #009933 , #4DDB4D);
-	margin-left: 0px;
-	margin-right: 0px;
-	padding: 10px;	
-	font-weight: 100;
-	font-size: xx-large;
-	color: white;
-	text-shadow: 2px 2px 4px #0D6E0E;
-	box-shadow: 0px 0px 10px black;
-}
-/* For header need to override link styles */
-#header a:link { color: white;}
-#header a:visited { color: white;}
-#header a:hover { font-weight: normal;}
-
 #mainDiv {
 	margin-left: auto;
 	margin-right: auto;
@@ -52,20 +35,6 @@ body {
 	margin-right: auto;
 	line-height: 125%;
 	margin-top: 5px;
-}
-
-/* Make links look better. No underlining, keep colors consistent. */
-a:link {
-	text-decoration: none;
-	color: #0000a6;
-}
-
-a:visited {
-	color: #0000a6;
-}
-
-a:hover {
-	color: #0000FF;
 }
 
 .ui-tooltip {

--- a/transitclockWebapp/src/main/webapp/javascript/controllers/active_blocks_controller.js
+++ b/transitclockWebapp/src/main/webapp/javascript/controllers/active_blocks_controller.js
@@ -2,15 +2,21 @@ import { Controller } from "https://unpkg.com/@hotwired/stimulus@3.2.2/dist/stim
 
 const SUMMARY_REFRESH_MS = 60_000;
 
-const ADH_CLASSES = Object.freeze({
-  early:  ["text-amber-700",   "bg-amber-50"],
-  onTime: ["text-emerald-700", "bg-emerald-50"],
-  late:   ["text-red-700",     "bg-red-50"],
+// Source of truth: OneBusAway design package (separate repo) at
+// project/assets/colors_and_type.css — red = early, green = on time,
+// violet = late.
+const STATUS_STYLES = Object.freeze({
+  early:  { text: "text-status-early",       bg: "bg-status-early/10",   solid: "bg-status-early"   },
+  onTime: { text: "text-status-on-time-ink", bg: "bg-status-on-time/10", solid: "bg-status-on-time" },
+  late:   { text: "text-status-late",        bg: "bg-status-late/10",    solid: "bg-status-late"    },
 });
-const ALL_ADH_CLASSES = [...new Set(Object.values(ADH_CLASSES).flat())];
+const ALL_ADH_CLASSES = Object.values(STATUS_STYLES).flatMap((s) => [s.text, s.bg]);
+const ALL_STRIPE_CLASSES = [...Object.values(STATUS_STYLES).map((s) => s.solid), "bg-gray-200"];
+
+const blocksLabel = (n) => `${n} ${n === 1 ? "block" : "blocks"}`;
 
 export default class extends Controller {
-  static targets = ["summary", "accordion", "routeTemplate", "blockTemplate", "loadAll"];
+  static targets = ["summary", "asOf", "accordion", "routeTemplate", "blockTemplate", "loadAll"];
   static values = {
     earlyMsec: Number,
     lateMsec: Number,
@@ -81,20 +87,31 @@ export default class extends Controller {
 
   #renderSummary(total) {
     const blocks = total.blocks ?? 0;
-    const vehicleCount = (total.late ?? 0) + (total.ontime ?? 0) + (total.early ?? 0);
+    const late = total.late ?? 0;
+    const onTime = total.ontime ?? 0;
+    const early = total.early ?? 0;
+    const assigned = late + onTime + early;
     const pct = (n) => (blocks ? `${((100 * n) / blocks).toFixed(0)}%` : "—");
 
     this.#fill("total-blocks", blocks);
-    this.#fill("percent-late", pct(total.late ?? 0));
-    this.#fill("percent-on-time", pct(total.ontime ?? 0));
-    this.#fill("percent-early", pct(total.early ?? 0));
-    this.#fill("as-of", new Date().toLocaleTimeString());
+    this.#fill("percent-late", pct(late));
+    this.#fill("percent-on-time", pct(onTime));
+    this.#fill("percent-early", pct(early));
+    this.#fill("late-count", late ? blocksLabel(late) : "");
+    this.#fill("on-time-count", onTime ? blocksLabel(onTime) : "");
+    this.#fill("early-count", early ? blocksLabel(early) : "");
+    this.#fill("assigned-detail", blocks ? `${assigned}/${blocks}` : "");
+
+    if (this.hasAsOfTarget) this.asOfTarget.textContent = new Date().toLocaleTimeString();
 
     const assignedEl = this.summaryTarget.querySelector("[data-field='percent-assigned']");
     if (assignedEl) {
-      assignedEl.textContent = pct(vehicleCount);
-      const assignedFrac = blocks ? vehicleCount / blocks : 1;
-      assignedEl.classList.toggle("text-red-600", assignedFrac < 0.9);
+      assignedEl.textContent = pct(assigned);
+      const assignedFrac = blocks ? assigned / blocks : 1;
+      // Drop the brand-accent color and switch to red when assignment is
+      // unhealthy, so the at-a-glance signal still reads correctly.
+      assignedEl.classList.toggle("text-brand-accent", assignedFrac >= 0.9);
+      assignedEl.classList.toggle("text-status-early", assignedFrac < 0.9);
     }
   }
 
@@ -121,8 +138,12 @@ export default class extends Controller {
         item.dataset.routeName = route.name;
         accordion.appendChild(item);
       }
+      const blockCount = route.block?.length ?? 0;
+      item.querySelector("[data-field='route-tag']").textContent = route.id;
       item.querySelector("[data-field='route-name']").textContent = route.name;
-      item.querySelector("[data-field='route-blocks']").textContent = route.block?.length ?? 0;
+      item.querySelector("[data-field='route-blocks']").textContent = blockCount;
+      item.querySelector("[data-field='route-blocks-noun']").textContent = blockCount === 1 ? "block" : "blocks";
+      item.querySelector("[data-field='route-blocks-denom']").textContent = blockCount;
     }
 
     for (const [id, el] of existing) {
@@ -146,29 +167,36 @@ export default class extends Controller {
     const vehicleTotal = early + onTime + late;
     const blockCount = (route.block ?? []).length;
 
-    const earlyEl   = item.querySelector("[data-field='route-early']");
-    const onTimeEl  = item.querySelector("[data-field='route-on-time']");
-    const lateEl    = item.querySelector("[data-field='route-late']");
-    const vehEl     = item.querySelector("[data-field='route-vehicles']");
-    const blocksEl  = item.querySelector("[data-field='route-blocks']");
+    item.querySelector("[data-field='route-early']").textContent = early;
+    item.querySelector("[data-field='route-on-time']").textContent = onTime;
+    item.querySelector("[data-field='route-late']").textContent = late;
+    item.querySelector("[data-field='route-blocks']").textContent = blockCount;
+    item.querySelector("[data-field='route-blocks-denom']").textContent = blockCount;
+    item.querySelector("[data-field='route-blocks-noun']").textContent = blockCount === 1 ? "block" : "blocks";
 
-    earlyEl.textContent  = early;
-    onTimeEl.textContent = onTime;
-    lateEl.textContent   = late;
-    vehEl.textContent    = vehicleTotal;
-    blocksEl.textContent = blockCount;
+    // Vehicle count below block count means the route is short-staffed;
+    // surface that as red regardless of the per-vehicle adherence colors.
+    const vehEl = item.querySelector("[data-field='route-vehicles']");
+    vehEl.textContent = vehicleTotal;
+    vehEl.classList.toggle("text-status-early", vehicleTotal < blockCount);
 
-    earlyEl.classList.toggle("text-amber-700", early > 0);
-    earlyEl.classList.toggle("bg-amber-50",    early > 0);
-    lateEl.classList.toggle("text-red-700",    late > 0);
-    lateEl.classList.toggle("bg-red-50",       late > 0);
-    const understaffed = vehicleTotal < blockCount;
-    vehEl.classList.toggle("text-red-700",     understaffed);
-    vehEl.classList.toggle("bg-red-50",        understaffed);
+    this.#toggleVisible(item, "route-early-pair", early > 0);
+    this.#toggleVisible(item, "route-on-time-pair", onTime > 0);
+    this.#toggleVisible(item, "route-late-pair", late > 0);
 
     const summary = item.querySelector("[data-vehicle-summary]");
     summary?.classList.remove("hidden");
     summary?.classList.add("flex");
+
+    // Stripe priority is late > early > on-time, falling back to neutral
+    // gray when no vehicles report yet — otherwise every unloaded card
+    // would mis-signal "all on time".
+    const stripe = item.querySelector("[data-field='route-stripe']");
+    if (stripe) {
+      stripe.classList.remove(...ALL_STRIPE_CLASSES);
+      const kind = late > 0 ? "late" : early > 0 ? "early" : onTime > 0 ? "onTime" : null;
+      stripe.classList.add(kind ? STATUS_STYLES[kind].solid : "bg-gray-200");
+    }
 
     const blockList = item.querySelector("[data-block-list]");
     blockList.replaceChildren();
@@ -177,15 +205,23 @@ export default class extends Controller {
     }
   }
 
+  #toggleVisible(item, field, visible) {
+    const el = item.querySelector(`[data-field='${field}']`);
+    if (!el) return;
+    el.classList.toggle("hidden", !visible);
+    el.classList.toggle("inline-flex", visible);
+  }
+
   #classifyAdh(schAdh) {
     if (schAdh < -this.lateMsecValue) return "late";
     if (schAdh > this.earlyMsecValue) return "early";
     return "onTime";
   }
 
-  #applyAdhClasses(el, schAdh) {
+  #applyAdhClasses(el, kind) {
     el.classList.remove(...ALL_ADH_CLASSES);
-    el.classList.add(...ADH_CLASSES[this.#classifyAdh(schAdh)]);
+    const style = STATUS_STYLES[kind];
+    el.classList.add(style.text, style.bg);
   }
 
   #renderBlock(block) {
@@ -213,8 +249,13 @@ export default class extends Controller {
 
     vehiclesEl.textContent = vehicles.map((v) => v.id).join(", ");
     const v0 = vehicles[0];
-    adhEl.textContent = v0.schAdhStr ?? "—";
-    this.#applyAdhClasses(adhEl, v0.schAdh);
+    const kind = this.#classifyAdh(parseInt(v0.schAdh, 10));
+    adhEl.replaceChildren();
+    const dot = document.createElement("span");
+    dot.className = `inline-block size-2 rounded-full ${STATUS_STYLES[kind].solid}`;
+    adhEl.appendChild(dot);
+    adhEl.appendChild(document.createTextNode(v0.schAdhStr ?? "—"));
+    this.#applyAdhClasses(adhEl, kind);
     return row;
   }
 }

--- a/transitclockWebapp/src/main/webapp/status/activeBlocks.jsp
+++ b/transitclockWebapp/src/main/webapp/status/activeBlocks.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html;charset=UTF-8" pageEncoding="UTF-8" %>
 <%@ page import="org.transitclock.reports.ScheduleAdherenceController" %>
 <%
 String agencyId = request.getParameter("a");
@@ -11,6 +12,7 @@ pageContext.setAttribute("earlyMsec",   scheduleEarlySec * -1000);
 pageContext.setAttribute("lateMsec",    scheduleLateSec  * 1000);
 pageContext.setAttribute("scheduleEarlyMin", scheduleEarlySec / -60);
 pageContext.setAttribute("scheduleLateMin",  scheduleLateSec  / 60);
+pageContext.setAttribute("currentYear",      java.time.Year.now().getValue());
 %>
 <t:layout>
   <jsp:attribute name="title"><fmt:message key="div.acbiveblock" /></jsp:attribute>
@@ -20,91 +22,123 @@ pageContext.setAttribute("scheduleLateMin",  scheduleLateSec  / 60);
      data-active-blocks-early-msec-value="${earlyMsec}"
      data-active-blocks-late-msec-value="${lateMsec}">
 
-  <%-- Sticky summary header. Bleeds full-width within main by undoing the
-       layout's p-8 padding via -mx-8/-mt-8, then re-applies px-8 itself. --%>
-  <div data-active-blocks-target="summary"
-       class="sticky top-0 z-10 -mx-8 -mt-8 mb-6 px-8 py-4 bg-white/95 backdrop-blur border-b border-gray-200">
-    <div class="flex flex-wrap items-center gap-x-6 gap-y-2">
-      <h1 class="mr-auto text-lg font-semibold text-gray-900"><fmt:message key="div.acbiveblock" /></h1>
-      <dl class="flex flex-wrap items-center gap-x-5 gap-y-1 text-sm">
-        <div class="flex items-baseline gap-1.5" title="Total number of blocks">
-          <dt class="text-gray-500"><fmt:message key="div.blocks" /></dt>
-          <dd data-field="total-blocks" class="font-mono text-gray-900">—</dd>
-        </div>
-        <div class="flex items-baseline gap-1.5" title="Percentage of blocks that have an assigned and predictable vehicle">
-          <dt class="text-gray-500"><fmt:message key="div.assigned" /></dt>
-          <dd data-field="percent-assigned" class="font-mono text-gray-900">—</dd>
-        </div>
-        <div class="flex items-baseline gap-1.5" title="Percentage of blocks where vehicle is more than ${scheduleLateMin} minutes late">
-          <dt class="text-gray-500"><fmt:message key="div.clate" />:</dt>
-          <dd data-field="percent-late" class="font-mono text-gray-900">—</dd>
-        </div>
-        <div class="flex items-baseline gap-1.5" title="Percentage of blocks where vehicle is on time">
-          <dt class="text-gray-500"><fmt:message key="div.contime" />:</dt>
-          <dd data-field="percent-on-time" class="font-mono text-gray-900">—</dd>
-        </div>
-        <div class="flex items-baseline gap-1.5" title="Percentage of blocks where vehicle is more than ${scheduleEarlyMin} minute(s) early">
-          <dt class="text-gray-500"><fmt:message key="div.cearly" />:</dt>
-          <dd data-field="percent-early" class="font-mono text-gray-900">—</dd>
-        </div>
-        <div class="flex items-baseline gap-1.5" title="Time that summary information was last updated">
-          <dt class="text-gray-500"><fmt:message key="div.AsOf" /></dt>
-          <dd data-field="as-of" class="font-mono text-gray-900">—</dd>
-        </div>
-      </dl>
+  <div class="flex items-end justify-between gap-4 flex-wrap mb-4">
+    <div>
+      <div class="flex items-center gap-1.5 text-xs text-gray-500 font-medium mb-1.5">
+        <fmt:message key="div.status"/>
+        <svg class="size-3 text-gray-400" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m9 6 6 6-6 6"/></svg>
+        <span class="text-gray-700"><fmt:message key="div.acbiveblock"/></span>
+      </div>
+      <h1 class="text-2xl font-bold tracking-tight text-gray-900 m-0"><fmt:message key="div.acbiveblock"/></h1>
+      <p class="mt-1 text-sm text-gray-500 m-0">Real-time status of vehicle assignments across the fleet.</p>
+    </div>
+    <div class="flex items-center gap-3">
+      <span class="text-xs text-gray-500 inline-flex items-center gap-1.5">
+        <svg class="size-3 text-gray-500" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 2"/></svg>
+        <fmt:message key="div.AsOf"/>
+        <span data-active-blocks-target="asOf" class="font-semibold text-gray-700 tabular-nums">—</span>
+      </span>
       <button type="button"
               data-action="click->active-blocks#loadAll"
               data-active-blocks-target="loadAll"
-              class="px-3 py-1.5 text-xs font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed">
-        <fmt:message key="div.LoadAllData" />
+              class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md border-0 bg-brand-accent text-white text-sm font-semibold shadow-sm hover:bg-brand disabled:opacity-50 disabled:cursor-not-allowed">
+        <svg class="size-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 4v12m0 0-4-4m4 4 4-4M4 20h16"/></svg>
+        <fmt:message key="div.LoadAllData"/>
       </button>
+    </div>
+  </div>
+
+  <%-- Bleeds out of the layout's p-8 padding via -mx-8 so the bar spans
+       the full main width and stays flush at the scroll-container edge. --%>
+  <div data-active-blocks-target="summary"
+       class="sticky top-0 z-10 -mx-8 mb-5 px-8 pt-3 pb-3 bg-canvas/90 backdrop-blur">
+    <div class="flex items-stretch bg-white border border-gray-200 rounded-lg overflow-hidden shadow-[0_1px_2px_rgba(0,0,0,0.03)]">
+      <div class="flex-1 min-w-0 px-4 py-3 border-r border-gray-200">
+        <div class="text-[11px] font-semibold uppercase tracking-wider text-gray-500"><fmt:message key="div.blocks"/></div>
+        <div class="flex items-baseline gap-1.5 mt-0.5">
+          <span data-field="total-blocks" class="text-[22px] font-bold tabular-nums text-gray-900">—</span>
+          <span class="text-xs text-gray-500 font-medium">total</span>
+        </div>
+      </div>
+      <div class="flex-1 min-w-0 px-4 py-3 border-r border-gray-200">
+        <div class="text-[11px] font-semibold uppercase tracking-wider text-gray-500"><fmt:message key="div.assigned"/></div>
+        <div class="flex items-baseline gap-1.5 mt-0.5">
+          <span data-field="percent-assigned" class="text-[22px] font-bold tabular-nums text-brand-accent">—</span>
+          <span data-field="assigned-detail" class="text-xs text-gray-500 font-medium tabular-nums"></span>
+        </div>
+      </div>
+      <div class="flex-1 min-w-0 px-4 py-3 border-r border-gray-200">
+        <div class="text-[11px] font-semibold uppercase tracking-wider text-gray-500"><fmt:message key="div.contime"/></div>
+        <div class="flex items-baseline gap-1.5 mt-0.5">
+          <span data-field="percent-on-time" class="text-[22px] font-bold tabular-nums text-status-on-time-ink">—</span>
+          <span data-field="on-time-count" class="text-xs text-gray-500 font-medium tabular-nums"></span>
+        </div>
+      </div>
+      <div class="flex-1 min-w-0 px-4 py-3 border-r border-gray-200" title="Vehicle is more than ${scheduleLateMin} min late">
+        <div class="text-[11px] font-semibold uppercase tracking-wider text-gray-500"><fmt:message key="div.clate"/></div>
+        <div class="flex items-baseline gap-1.5 mt-0.5">
+          <span data-field="percent-late" class="text-[22px] font-bold tabular-nums text-status-late">—</span>
+          <span data-field="late-count" class="text-xs text-gray-500 font-medium tabular-nums"></span>
+        </div>
+      </div>
+      <div class="flex-1 min-w-0 px-4 py-3" title="Vehicle is more than ${scheduleEarlyMin} min early">
+        <div class="text-[11px] font-semibold uppercase tracking-wider text-gray-500"><fmt:message key="div.cearly"/></div>
+        <div class="flex items-baseline gap-1.5 mt-0.5">
+          <span data-field="percent-early" class="text-[22px] font-bold tabular-nums text-status-early">—</span>
+          <span data-field="early-count" class="text-xs text-gray-500 font-medium tabular-nums"></span>
+        </div>
+      </div>
     </div>
   </div>
 
   <div data-controller="accordion"
        data-accordion-allow-multiple-value="true"
        data-active-blocks-target="accordion"
-       class="bg-white border border-gray-200 rounded-lg divide-y divide-gray-200 overflow-hidden">
+       class="space-y-2">
     <t:loading/>
   </div>
 
+  <%-- Block list inside the body hydrates lazily on first accordion open
+       via the `accordion:opened` event wired up at the controller root. --%>
   <template data-active-blocks-target="routeTemplate">
-    <div data-accordion-target="item" data-state="closed" class="group">
+    <div data-accordion-target="item" data-state="closed" class="group bg-white border border-gray-200 rounded-lg overflow-hidden shadow-[0_1px_2px_rgba(0,0,0,0.04)]">
       <h3 class="m-0">
         <button type="button"
                 data-accordion-target="trigger"
                 data-action="click->accordion#toggle"
                 aria-expanded="false"
                 data-state="closed"
-                class="w-full flex items-center justify-between gap-4 px-4 py-3 text-left hover:bg-gray-50">
-          <span class="flex items-center gap-3 min-w-0">
-            <span data-field="route-name" class="text-sm font-semibold text-gray-900 truncate"></span>
+                class="w-full grid grid-cols-[4px_auto_1fr_auto_auto] items-center gap-3.5 pl-0 pr-3 py-2.5 text-left bg-white hover:bg-[#fafbf8]">
+          <span data-field="route-stripe" class="block w-1 h-8 rounded-r-sm bg-gray-200"></span>
+          <span data-field="route-tag" class="inline-flex items-center justify-center min-w-[44px] px-2 py-0.5 rounded bg-brand-accent text-white text-xs font-bold tracking-tight ml-2">—</span>
+          <span class="flex items-baseline gap-2.5 min-w-0">
+            <span data-field="route-name" class="text-[15px] font-semibold text-gray-900 truncate"></span>
+            <span class="text-xs text-gray-500 whitespace-nowrap">
+              <span data-field="route-blocks" class="tabular-nums">0</span>
+              <span data-field="route-blocks-noun"><fmt:message key="div.dblock"/></span>
+            </span>
           </span>
-          <span class="flex items-center gap-3">
-            <span data-vehicle-summary class="hidden items-center gap-2 text-xs">
-              <span class="flex items-baseline gap-1">
-                <span class="text-gray-500"><fmt:message key="div.cearly" /></span>
-                <span data-field="route-early" class="px-1.5 py-0.5 rounded font-mono text-gray-900">0</span>
-              </span>
-              <span class="flex items-baseline gap-1">
-                <span class="text-gray-500"><fmt:message key="div.contime" /></span>
-                <span data-field="route-on-time" class="px-1.5 py-0.5 rounded font-mono text-gray-900">0</span>
-              </span>
-              <span class="flex items-baseline gap-1">
-                <span class="text-gray-500"><fmt:message key="div.clate" /></span>
-                <span data-field="route-late" class="px-1.5 py-0.5 rounded font-mono text-gray-900">0</span>
-              </span>
-              <span class="flex items-baseline gap-1">
-                <span class="text-gray-500"><fmt:message key="div.assigned" /></span>
-                <span data-field="route-vehicles" class="px-1.5 py-0.5 rounded font-mono text-gray-900">0</span>
-              </span>
+          <span data-vehicle-summary class="hidden items-center gap-3.5 text-xs">
+            <span data-field="route-early-pair" class="hidden items-center gap-1">
+              <span class="text-gray-500"><fmt:message key="div.cearly"/></span>
+              <span data-field="route-early" class="font-bold text-status-early tabular-nums">0</span>
             </span>
-            <span class="flex items-baseline gap-1 text-xs">
-              <span class="text-gray-500"><fmt:message key="div.dblock" /></span>
-              <span data-field="route-blocks" class="px-1.5 py-0.5 rounded font-mono text-gray-900">0</span>
+            <span data-field="route-on-time-pair" class="hidden items-center gap-1">
+              <span class="text-gray-500"><fmt:message key="div.contime"/></span>
+              <span data-field="route-on-time" class="font-bold text-status-on-time-ink tabular-nums">0</span>
             </span>
-            <svg xmlns="http://www.w3.org/2000/svg" class="size-4 shrink-0 text-gray-400 transition-transform duration-200 group-data-[state=open]:rotate-180" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-              <path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 011.06.02L10 11.168l3.71-3.938a.75.75 0 111.08 1.04l-4.25 4.5a.75.75 0 01-1.08 0l-4.25-4.5a.75.75 0 01.02-1.06z" clip-rule="evenodd"/>
+            <span data-field="route-late-pair" class="hidden items-center gap-1">
+              <span class="text-gray-500"><fmt:message key="div.clate"/></span>
+              <span data-field="route-late" class="font-bold text-status-late tabular-nums">0</span>
+            </span>
+          </span>
+          <span class="flex items-center gap-3 pr-1">
+            <span class="text-xs text-gray-500 font-medium hidden sm:inline-flex items-baseline gap-1">
+              <fmt:message key="div.assigned"/>
+              <span class="text-gray-900 font-bold tabular-nums"><span data-field="route-vehicles">0</span>/<span data-field="route-blocks-denom">0</span></span>
+            </span>
+            <svg class="size-4 shrink-0 text-gray-400 transition-transform duration-200 group-data-[state=open]:rotate-90" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <path d="m9 6 6 6-6 6"/>
             </svg>
           </span>
         </button>
@@ -115,8 +149,8 @@ pageContext.setAttribute("scheduleLateMin",  scheduleLateSec  / 60);
            role="region"
            class="grid transition-[grid-template-rows] duration-300 ease-in-out data-[state=open]:grid-rows-[1fr] data-[state=closed]:grid-rows-[0fr]">
         <div class="overflow-hidden min-h-0">
-          <div data-state="closed" class="px-4 py-3 space-y-2 bg-gray-50/50 transition-opacity duration-200 opacity-0 data-[state=open]:opacity-100">
-            <div data-block-list class="space-y-2"></div>
+          <div data-state="closed" class="bg-[#fafbf8] border-t border-gray-200 transition-opacity duration-200 opacity-0 data-[state=open]:opacity-100">
+            <div data-block-list></div>
           </div>
         </div>
       </div>
@@ -124,49 +158,48 @@ pageContext.setAttribute("scheduleLateMin",  scheduleLateSec  / 60);
   </template>
 
   <template data-active-blocks-target="blockTemplate">
-    <div class="bg-white border border-gray-200 rounded-md px-3 py-2 grid grid-cols-2 md:grid-cols-4 gap-x-4 gap-y-1.5 text-xs">
-      <div class="flex items-baseline gap-1.5">
-        <dt class="text-gray-500"><fmt:message key="div.dblock" />:</dt>
-        <dd data-field="block-id" class="font-mono text-gray-900"></dd>
+    <div class="grid grid-cols-2 md:grid-cols-[0.9fr_1.4fr_1.6fr_1fr_1.6fr] gap-x-4 gap-y-2 px-4 py-3 border-t border-gray-100 bg-white text-[13px]">
+      <div>
+        <div class="text-[11px] font-semibold uppercase tracking-wider text-gray-500"><fmt:message key="div.dblock"/></div>
+        <div data-field="block-id" class="font-semibold font-mono text-gray-900"></div>
+        <div class="text-xs text-gray-500 mt-0.5"><fmt:message key="div.dtrip"/> <span data-field="trip-id" class="font-mono"></span></div>
       </div>
-      <div class="flex items-baseline gap-1.5">
-        <dt class="text-gray-500"><fmt:message key="div.Start" /></dt>
-        <dd data-field="block-start" class="font-mono text-gray-900"></dd>
+      <div>
+        <div class="text-[11px] font-semibold uppercase tracking-wider text-gray-500"><fmt:message key="div.Vehicle"/></div>
+        <div class="flex items-center gap-1.5 mt-0.5">
+          <svg class="size-3.5 text-gray-500" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="4" y="4" width="16" height="14" rx="2"/><path d="M4 11h16M7 18v2M17 18v2M9 15h.01M15 15h.01"/></svg>
+          <span data-field="block-vehicles" class="font-semibold font-mono text-gray-900"></span>
+        </div>
+        <div class="text-xs text-gray-500 mt-0.5"><fmt:message key="div.Service"/> <span data-field="block-service" class="font-mono"></span></div>
       </div>
-      <div class="flex items-baseline gap-1.5">
-        <dt class="text-gray-500"><fmt:message key="div.End" /></dt>
-        <dd data-field="block-end" class="font-mono text-gray-900"></dd>
+      <div>
+        <div class="text-[11px] font-semibold uppercase tracking-wider text-gray-500"><fmt:message key="div.Schedule"/></div>
+        <div class="flex items-center gap-1.5 mt-0.5 font-mono text-[12.5px] text-gray-900">
+          <span data-field="block-start"></span>
+          <span class="text-gray-400">&rarr;</span>
+          <span data-field="block-end"></span>
+        </div>
+        <div class="text-xs text-gray-500 mt-0.5">
+          <fmt:message key="div.dtrip"/> <span data-field="trip-start" class="font-mono"></span>
+          <span class="text-gray-400">&rarr;</span>
+          <span data-field="trip-end" class="font-mono"></span>
+        </div>
       </div>
-      <div class="flex items-baseline gap-1.5">
-        <dt class="text-gray-500"><fmt:message key="div.Service" /></dt>
-        <dd data-field="block-service" class="font-mono text-gray-900 truncate"></dd>
+      <div>
+        <div class="text-[11px] font-semibold uppercase tracking-wider text-gray-500"><fmt:message key="div.Adh"/></div>
+        <div class="mt-1"><span data-field="block-sch-adh" class="inline-flex items-center gap-1.5 px-1.5 py-0.5 rounded font-mono text-xs font-semibold"></span></div>
       </div>
-      <div class="flex items-baseline gap-1.5">
-        <dt class="text-gray-500"><fmt:message key="div.dtrip" />:</dt>
-        <dd data-field="trip-id" class="font-mono text-gray-900"></dd>
-      </div>
-      <div class="flex items-baseline gap-1.5">
-        <dt class="text-gray-500"><fmt:message key="div.Start" /></dt>
-        <dd data-field="trip-start" class="font-mono text-gray-900"></dd>
-      </div>
-      <div class="flex items-baseline gap-1.5">
-        <dt class="text-gray-500"><fmt:message key="div.End" /></dt>
-        <dd data-field="trip-end" class="font-mono text-gray-900"></dd>
-      </div>
-      <div class="flex items-baseline gap-1.5 col-span-2 md:col-span-1">
-        <dt class="text-gray-500"><fmt:message key="div.Headsign" />:</dt>
-        <dd data-field="trip-headsign" class="text-gray-900 truncate"></dd>
-      </div>
-      <div class="flex items-baseline gap-1.5 col-span-2">
-        <dt class="text-gray-500"><fmt:message key="div.Vehicle" />:</dt>
-        <dd data-field="block-vehicles" class="font-mono text-gray-900"></dd>
-      </div>
-      <div class="flex items-baseline gap-1.5 col-span-2">
-        <dt class="text-gray-500"><fmt:message key="div.Adh" /></dt>
-        <dd data-field="block-sch-adh" class="px-1.5 py-0.5 rounded font-mono"></dd>
+      <div>
+        <div class="text-[11px] font-semibold uppercase tracking-wider text-gray-500"><fmt:message key="div.Headsign"/></div>
+        <div data-field="trip-headsign" class="text-gray-900 font-medium mt-0.5 truncate"></div>
       </div>
     </div>
   </template>
+
+  <footer class="mt-8 pt-4 border-t border-gray-200 flex justify-between text-xs text-gray-500">
+    <span>OneBusAway &middot; The Transit Clock</span>
+    <span>OTSF &copy; ${currentYear}</span>
+  </footer>
 </div>
   </jsp:body>
 </t:layout>

--- a/transitclockWebapp/src/main/webapp/template/header.jsp
+++ b/transitclockWebapp/src/main/webapp/template/header.jsp
@@ -1,3 +1,0 @@
-<%-- Contains a header that should be included into most web pages --%>
-
-<div id="header"><a href="http://www.thetransitclock.org">The Transit Clock</a></div>


### PR DESCRIPTION
## Summary

- Replaces the sidebar-only header with a sticky transit-green brand bar (logo + agency wordmark + live clock), regroups the sidebar into `agency / Status / Operations` sections with icons and a left-edge active pill, and restyles the Active Blocks page around a sticky 5-tile stat bar, route cards with status stripes, and per-vehicle status badges.
- Adds `@theme` brand and status tokens (`--color-brand`, `--color-brand-accent`, `--color-canvas`, status palette) to the Tailwind input so utilities like `bg-brand`, `text-status-late`, `bg-status-on-time/10` resolve from a single source.
- Deletes the orphaned `template/header.jsp` and the legacy global `a:link` / `#header` rules in `general.css` that the new brand bar replaces.

Behavior is unchanged: the Active Blocks controller still drives the same accordion and summary endpoints, and per the design hand-off the new filter pills / search box / expand-all toggle / refresh button were intentionally **not** built — the redesign was scoped to visual chrome, not net-new features.

## Test plan

- [x] Brand bar + sidebar render correctly on the welcome page (no agency selected → "The Transit Clock" only) and on a per-agency page (agency name as wordmark)
- [x] Active Blocks: pre-load state shows neutral gray stripes; post-load swaps to the right color (verified with the only route on the test fixture that has a > 7-min-late vehicle — stripe flips to violet, "Late 1" mini-count appears)
- [x] Stat tile bar populates real data and stays sticky on scroll
- [x] Schedule column header resolves via the new `div.Schedule` bundle key (caveat: requires Tomcat restart for ResourceBundle reload)
- [x] `&rarr;` arrows render correctly under Tomcat's default JSP encoding (the new `<%@ page contentType="text/html;charset=UTF-8" %>` directive defends future literals)
- [x] Server Status, Database Disk Space, and the Maps disclosure (with auto-expand on the active sub-page) all render with the redesigned layout
- [x] Map page bleeds full-width with the brand bar pinned at top
- [x] `mvn -pl transitclockWebapp -am package -DskipTests` builds the WAR cleanly; `npm run build` produces the new utilities in `target/frontend-dist/tailwind.css`; `npm test -- --run` passes

## Review notes (out of scope, surfaced for visibility)

These are pre-existing behaviors the redesign didn't introduce; documenting here so the reviewer can decide whether to file follow-ups:

- **`#getJSON` swallows fetch errors into `null`** — a 401 / 503 / RMI-down state leaves the summary as a static `—` with no operator-visible signal. Worth surfacing failure on the `asOf` element in a follow-up.
- **`#renderRouteData` template lookups are unguarded** — if a `data-field` is renamed in the JSP without a controller update, rendering throws mid-loop and `loadAll`'s `Promise.all` rejects. Consistent with `#fill`'s safer pattern would be to guard or assert at the top.
- **Live-clock `setInterval` has no cleanup** — harmless under the multi-page JSP model (page reload GCs the timer), but theoretical concern if anything ever swaps the layout via a frame.
- **Accordion content has `role="region"` without an accessible name** — pre-existing; would need a generated id per route card.
- **A few UI strings are still hardcoded English** (subtitle, "Live", footer, the controller's `block`/`blocks` plural) where the rest of the page uses `<fmt:message>`. Fit-and-finish for a follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Redesigned navigation interface with improved visual hierarchy and iconized sidebar organization
  * Reorganized active blocks status display with new grid-based card layout
  * Enhanced status indicators with distinct color scheme distinguishing on-time, early, and late statuses
  * Updated header branding and page layout structure
  * Implemented unified styling scheme across the application interface

<!-- end of auto-generated comment: release notes by coderabbit.ai -->