### PR TITLE
Vend DB disk-space stats via authenticated JAX-RS endpoint

### DIFF
--- a/transitclockWebapp/pom.xml
+++ b/transitclockWebapp/pom.xml
@@ -11,6 +11,9 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<!-- Keep in sync with transitclockApi: jakarta-namespace Jersey
+		     line implementing Jakarta REST 3.1 / Jakarta EE 10. -->
+		<jersey.version>3.1.7</jersey.version>
 	</properties>
 
 	<!-- See root pom.xml: pins JAXB 2.x build-POM transitives to working
@@ -87,12 +90,66 @@
 			<groupId>TheTransitClock</groupId>
 			<artifactId>transitclockCore</artifactId>
 			<version>3.0.0-SNAPSHOT</version>
+			<!-- Strip the pre-Jakarta Jersey 2.11 (2014) jars that
+			     transitclockTraccarClient drags in. The webapp doesn't
+			     invoke Traccar's HTTP client, but jersey-media-json-jackson
+			     2.11 ships a META-INF/services entry registering
+			     org.glassfish.jersey.jackson.internal.DefaultJacksonJaxbJsonProvider,
+			     which Jersey 3.1's WebApiApplication picks up at servlet
+			     init. Instantiating that 2.x provider against the 2.8.9
+			     jackson chain blows up on a missing JacksonFeature class,
+			     killing the entire JAX-RS context. Excluding here keeps
+			     Core's own build/runtime untouched (exclusions are
+			     per-consumer). -->
+			<exclusions>
+				<exclusion>
+					<groupId>org.glassfish.jersey.core</groupId>
+					<artifactId>jersey-client</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.glassfish.jersey.media</groupId>
+					<artifactId>jersey-media-json-jackson</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.glassfish.jersey.media</groupId>
+					<artifactId>jersey-media-multipart</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.glassfish.web</groupId>
 			<artifactId>jakarta.servlet.jsp.jstl</artifactId>
 			<version>3.0.1</version>
 		</dependency>
+
+		<!-- JAX-RS for the webapp-internal JSON layer served at /api/*.
+		     Distinct from transitclockApi's /v1/* surface: this layer is
+		     for endpoints that talk to the DB directly rather than to
+		     Core via RMI (e.g. db-disk-space). -->
+		<dependency>
+			<groupId>jakarta.ws.rs</groupId>
+			<artifactId>jakarta.ws.rs-api</artifactId>
+			<version>3.1.0</version>
+		</dependency>
+		<dependency>
+			<groupId>org.glassfish.jersey.containers</groupId>
+			<artifactId>jersey-container-servlet</artifactId>
+			<version>${jersey.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.glassfish.jersey.inject</groupId>
+			<artifactId>jersey-hk2</artifactId>
+			<version>${jersey.version}</version>
+		</dependency>
+		<!-- Intentionally NOT pulling in a JSON-binding provider
+		     (jersey-media-json-jackson / jersey-media-moxy). Jersey 3.1.7's
+		     jersey-media-json-jackson forces jackson-databind to 2.17.x while
+		     transitclockCore's transitive Jackson chain stays at 2.8.9, which
+		     breaks Hibernate's JacksonIntegration static init at runtime.
+		     Endpoints that need to vend JSON should return a pre-serialized
+		     String wrapped in Response.ok(...).type(APPLICATION_JSON), the
+		     way DbDiskSpaceResource does. Revisit if/when an endpoint needs
+		     POJO marshalling and the core Jackson chain is unified. -->
 
 	</dependencies>
 	<build>

--- a/transitclockWebapp/pom.xml
+++ b/transitclockWebapp/pom.xml
@@ -64,6 +64,40 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+			<version>5.12.0</version>
+			<scope>test</scope>
+		</dependency>
+		<!-- Jersey Test Framework: same usage and jupiter-exclusion
+		     rationale as transitclockApi/pom.xml. Spins the JAX-RS layer
+		     in-process on Grizzly2 so DbDiskSpaceResource can be
+		     exercised end-to-end without Tomcat. -->
+		<dependency>
+			<groupId>org.glassfish.jersey.test-framework</groupId>
+			<artifactId>jersey-test-framework-core</artifactId>
+			<version>${jersey.version}</version>
+			<scope>test</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>org.junit.jupiter</groupId>
+					<artifactId>junit-jupiter</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>org.glassfish.jersey.test-framework.providers</groupId>
+			<artifactId>jersey-test-framework-provider-grizzly2</artifactId>
+			<version>${jersey.version}</version>
+			<scope>test</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>org.junit.jupiter</groupId>
+					<artifactId>junit-jupiter</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
 			<groupId>jakarta.servlet</groupId>
 			<artifactId>jakarta.servlet-api</artifactId>
 			<version>6.1.0</version>

--- a/transitclockWebapp/src/main/java/org/transitclock/reports/DbDiskSpaceQuery.java
+++ b/transitclockWebapp/src/main/java/org/transitclock/reports/DbDiskSpaceQuery.java
@@ -30,13 +30,18 @@ public final class DbDiskSpaceQuery {
                     + "    AND nspname !~ '^pg_toast' "
                     + ") "
                     + "UNION "
+                    // Total row must use the same size function (pg_total_relation_size:
+                    // main + indexes + TOAST) and the same WHERE filters as the per-row
+                    // inner SELECT, otherwise it under- or double-counts.
                     + "SELECT 'Total:', "
-                    + "       pg_size_pretty(SUM(pg_relation_size(C.oid))), "
-                    + "       SUM(pg_relation_size(C.oid)), "
+                    + "       pg_size_pretty(SUM(pg_total_relation_size(C.oid))), "
+                    + "       SUM(pg_total_relation_size(C.oid)), "
                     + "       2 as ordering "
                     + "  FROM pg_class C "
                     + "  LEFT JOIN pg_namespace N ON (N.oid = C.relnamespace) "
                     + " WHERE nspname NOT IN ('pg_catalog', 'information_schema') "
+                    + "   AND C.relkind <> 'i' "
+                    + "   AND nspname !~ '^pg_toast' "
                     + ") AS needed_alias_name "
                     + "ORDER BY ordering, \"Total Bytes\" DESC";
 

--- a/transitclockWebapp/src/main/java/org/transitclock/reports/DbDiskSpaceQuery.java
+++ b/transitclockWebapp/src/main/java/org/transitclock/reports/DbDiskSpaceQuery.java
@@ -1,0 +1,65 @@
+package org.transitclock.reports;
+
+import java.sql.SQLException;
+
+/**
+ * Postgres-catalog queries for per-table on-disk size, returned as
+ * Google Charts DataTable JSON. Used by status/dbDiskSpace.jsp (server-side
+ * render) and by the JAX-RS endpoint at /api/status/db-disk-space (external
+ * authorized clients). Centralized here so the SQL doesn't drift between
+ * the two callers.
+ */
+public final class DbDiskSpaceQuery {
+
+    // Two queries unioned so the "Total:" row stays at the bottom regardless
+    // of how the table is later sorted client-side. The outer SELECT drops
+    // the ordering column and renames the rest to human-readable headers.
+    private static final String TOTALS_SQL =
+            "SELECT relname AS \"Table Name\", "
+                    + "     total_size AS \"Total Size\", "
+                    + "     total_bytes AS \"Total Bytes\" "
+                    + " FROM "
+                    + "((SELECT relname , "
+                    + "        pg_size_pretty(pg_total_relation_size(C.oid)) AS total_size, "
+                    + "        pg_total_relation_size(C.oid) AS total_bytes, "
+                    + "        1 AS ordering"
+                    + "   FROM pg_class C "
+                    + "   LEFT JOIN pg_namespace N ON (N.oid = C.relnamespace) "
+                    + "  WHERE nspname NOT IN ('pg_catalog', 'information_schema') "
+                    + "    AND C.relkind <> 'i' "
+                    + "    AND nspname !~ '^pg_toast' "
+                    + ") "
+                    + "UNION "
+                    + "SELECT 'Total:', "
+                    + "       pg_size_pretty(SUM(pg_relation_size(C.oid))), "
+                    + "       SUM(pg_relation_size(C.oid)), "
+                    + "       2 as ordering "
+                    + "  FROM pg_class C "
+                    + "  LEFT JOIN pg_namespace N ON (N.oid = C.relnamespace) "
+                    + " WHERE nspname NOT IN ('pg_catalog', 'information_schema') "
+                    + ") AS needed_alias_name "
+                    + "ORDER BY ordering, \"Total Bytes\" DESC";
+
+    // Detail view: one row per user relation (tables and indexes). Toast
+    // tables are filtered out as standalone rows; their bytes still roll
+    // into pg_total_relation_size for the owning table.
+    private static final String DETAILS_SQL =
+            "SELECT relname AS \"Table Name\", "
+                    + "pg_size_pretty(pg_total_relation_size(C.oid)) AS \"Total Size\", "
+                    + "pg_total_relation_size(C.oid) AS \"Total Bytes\" "
+                    + "FROM pg_class C "
+                    + "LEFT JOIN pg_namespace N ON (N.oid = C.relnamespace) "
+                    + "WHERE nspname NOT IN ('pg_catalog', 'information_schema') "
+                    + "    AND nspname !~ '^pg_toast' "
+                    + "ORDER BY pg_total_relation_size(C.oid) DESC";
+
+    private DbDiskSpaceQuery() {}
+
+    public static String getTotalsJson(String agencyId) throws SQLException {
+        return ChartGenericJsonQuery.getJsonString(agencyId, TOTALS_SQL, null, null);
+    }
+
+    public static String getDetailsJson(String agencyId) throws SQLException {
+        return ChartGenericJsonQuery.getJsonString(agencyId, DETAILS_SQL);
+    }
+}

--- a/transitclockWebapp/src/main/java/org/transitclock/reports/DbDiskSpaceQuery.java
+++ b/transitclockWebapp/src/main/java/org/transitclock/reports/DbDiskSpaceQuery.java
@@ -56,7 +56,7 @@ public final class DbDiskSpaceQuery {
     private DbDiskSpaceQuery() {}
 
     public static String getTotalsJson(String agencyId) throws SQLException {
-        return ChartGenericJsonQuery.getJsonString(agencyId, TOTALS_SQL, null, null);
+        return ChartGenericJsonQuery.getJsonString(agencyId, TOTALS_SQL);
     }
 
     public static String getDetailsJson(String agencyId) throws SQLException {

--- a/transitclockWebapp/src/main/java/org/transitclock/web/api/DbDiskSpaceResource.java
+++ b/transitclockWebapp/src/main/java/org/transitclock/web/api/DbDiskSpaceResource.java
@@ -1,0 +1,67 @@
+package org.transitclock.web.api;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response.Status;
+import java.sql.SQLException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.transitclock.db.webstructs.ApiKeyManager;
+import org.transitclock.reports.DbDiskSpaceQuery;
+
+/**
+ * GET /api/status/db-disk-space?a=&lt;agency&gt;&amp;k=&lt;apiKey&gt;
+ *
+ * Returns Postgres on-disk size info for the given agency's DB. Body is
+ * {"totals": &lt;Google Charts DataTable JSON&gt;, "details": &lt;ditto&gt;}; either
+ * member may be null if the underlying query produced no rows. Requires a
+ * valid API key — the same key namespace transitclockApi uses (managed via
+ * the CreateAPIKey shaded jar).
+ */
+@Path("status/db-disk-space")
+public class DbDiskSpaceResource {
+
+    private static final Logger logger = LoggerFactory.getLogger(DbDiskSpaceResource.class);
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response get(@QueryParam("a") String agencyId,
+                        @QueryParam("k") String apiKey) {
+        requireValidKey(apiKey);
+        if (agencyId == null || agencyId.isEmpty()) {
+            throw error(Status.BAD_REQUEST, "Missing required query parameter 'a' (agency id)");
+        }
+
+        try {
+            String totals = DbDiskSpaceQuery.getTotalsJson(agencyId);
+            String details = DbDiskSpaceQuery.getDetailsJson(agencyId);
+            // Both query results are already valid JSON (or null); concatenate
+            // raw to avoid a parse/re-serialize round-trip.
+            String body = "{\"totals\":" + (totals != null ? totals : "null")
+                    + ",\"details\":" + (details != null ? details : "null") + "}";
+            return Response.ok(body).type(MediaType.APPLICATION_JSON).build();
+        } catch (SQLException | RuntimeException e) {
+            // Log the full stack server-side; return a generic body so we
+            // don't leak Postgres error text (schema names, role names,
+            // connection URLs) to API clients.
+            logger.error("db-disk-space query failed for agency={}", agencyId, e);
+            throw error(Status.INTERNAL_SERVER_ERROR, "Database query failed; see server logs.");
+        }
+    }
+
+    private static void requireValidKey(String key) {
+        if (key == null || key.isEmpty() || !ApiKeyManager.getInstance().isKeyValid(key)) {
+            throw error(Status.UNAUTHORIZED, "Missing or invalid API key (query param 'k')");
+        }
+    }
+
+    private static WebApplicationException error(Status status, String message) {
+        return new WebApplicationException(
+                Response.status(status).entity(message).type(MediaType.TEXT_PLAIN).build());
+    }
+}

--- a/transitclockWebapp/src/main/java/org/transitclock/web/api/DbDiskSpaceResource.java
+++ b/transitclockWebapp/src/main/java/org/transitclock/web/api/DbDiskSpaceResource.java
@@ -44,9 +44,6 @@ public class DbDiskSpaceResource {
              k -> ApiKeyManager.getInstance().isKeyValid(k));
     }
 
-    // Package-private for unit tests: lets DbDiskSpaceResourceTest hand in
-    // fakes without depending on Mockito's thread-local static mocking,
-    // which JerseyTest's Grizzly worker threads don't see.
     DbDiskSpaceResource(AgencyQuery totalsFn,
                         AgencyQuery detailsFn,
                         Predicate<String> apiKeyValidator) {

--- a/transitclockWebapp/src/main/java/org/transitclock/web/api/DbDiskSpaceResource.java
+++ b/transitclockWebapp/src/main/java/org/transitclock/web/api/DbDiskSpaceResource.java
@@ -9,6 +9,7 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.Response.Status;
 import java.sql.SQLException;
+import java.util.function.Predicate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.transitclock.db.webstructs.ApiKeyManager;
@@ -28,6 +29,32 @@ public class DbDiskSpaceResource {
 
     private static final Logger logger = LoggerFactory.getLogger(DbDiskSpaceResource.class);
 
+    @FunctionalInterface
+    interface AgencyQuery {
+        String run(String agencyId) throws SQLException;
+    }
+
+    private final AgencyQuery totalsFn;
+    private final AgencyQuery detailsFn;
+    private final Predicate<String> apiKeyValidator;
+
+    public DbDiskSpaceResource() {
+        this(DbDiskSpaceQuery::getTotalsJson,
+             DbDiskSpaceQuery::getDetailsJson,
+             k -> ApiKeyManager.getInstance().isKeyValid(k));
+    }
+
+    // Package-private for unit tests: lets DbDiskSpaceResourceTest hand in
+    // fakes without depending on Mockito's thread-local static mocking,
+    // which JerseyTest's Grizzly worker threads don't see.
+    DbDiskSpaceResource(AgencyQuery totalsFn,
+                        AgencyQuery detailsFn,
+                        Predicate<String> apiKeyValidator) {
+        this.totalsFn = totalsFn;
+        this.detailsFn = detailsFn;
+        this.apiKeyValidator = apiKeyValidator;
+    }
+
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     public Response get(@QueryParam("a") String agencyId,
@@ -38,8 +65,8 @@ public class DbDiskSpaceResource {
         }
 
         try {
-            String totals = DbDiskSpaceQuery.getTotalsJson(agencyId);
-            String details = DbDiskSpaceQuery.getDetailsJson(agencyId);
+            String totals = totalsFn.run(agencyId);
+            String details = detailsFn.run(agencyId);
             // Both query results are already valid JSON (or null); concatenate
             // raw to avoid a parse/re-serialize round-trip.
             String body = "{\"totals\":" + (totals != null ? totals : "null")
@@ -54,8 +81,8 @@ public class DbDiskSpaceResource {
         }
     }
 
-    private static void requireValidKey(String key) {
-        if (key == null || key.isEmpty() || !ApiKeyManager.getInstance().isKeyValid(key)) {
+    private void requireValidKey(String key) {
+        if (key == null || key.isEmpty() || !apiKeyValidator.test(key)) {
             throw error(Status.UNAUTHORIZED, "Missing or invalid API key (query param 'k')");
         }
     }

--- a/transitclockWebapp/src/main/java/org/transitclock/web/api/WebApiApplication.java
+++ b/transitclockWebapp/src/main/java/org/transitclock/web/api/WebApiApplication.java
@@ -1,0 +1,18 @@
+package org.transitclock.web.api;
+
+import jakarta.ws.rs.ApplicationPath;
+import org.glassfish.jersey.server.ResourceConfig;
+
+/**
+ * Webapp-internal JSON layer mounted at /api/*. Distinct from
+ * transitclockApi's /v1/* surface: this layer is for endpoints that talk
+ * to the DB directly (e.g. db-disk-space) rather than to a Core JVM via
+ * RMI. JAX-RS resource classes live in this package and are discovered
+ * by Jersey's package scan.
+ */
+@ApplicationPath("api")
+public class WebApiApplication extends ResourceConfig {
+    public WebApiApplication() {
+        packages("org.transitclock.web.api");
+    }
+}

--- a/transitclockWebapp/src/main/webapp/status/dbDiskSpace.jsp
+++ b/transitclockWebapp/src/main/webapp/status/dbDiskSpace.jsp
@@ -1,4 +1,4 @@
-<%@ page import="org.transitclock.reports.ChartGenericJsonQuery" %>
+<%@ page import="org.transitclock.reports.DbDiskSpaceQuery" %>
 <%
 String agencyId = request.getParameter("a");
 if (agencyId == null || agencyId.isEmpty()) {
@@ -6,50 +6,8 @@ if (agencyId == null || agencyId.isEmpty()) {
     return;
 }
 
-// This query is rather complicated. Want the values in order but also
-// want total at end. Using two queries and a union to do this but
-// need to also use an ordering column so that the total will always
-// be at the end. And then need to do a select on the whole result
-// to get rid of the ordering column and to provde human readable
-// column titles like "Table Size".
-String sql =
-        "SELECT relname AS \"Table Name\", "
-            + "     total_size AS \"Total Size\", "
-            + "     total_bytes AS \"Total Bytes\" "
-            + " FROM "
-            + "((SELECT relname , "
-            + "        pg_size_pretty(pg_total_relation_size(C.oid)) AS total_size, "
-            + "        pg_total_relation_size(C.oid) AS total_bytes, "
-            + "        1 AS ordering"
-            + "   FROM pg_class C "
-            + "   LEFT JOIN pg_namespace N ON (N.oid = C.relnamespace) "
-            + "  WHERE nspname NOT IN ('pg_catalog', 'information_schema') "
-            + "    AND C.relkind <> 'i' "
-            + "    AND nspname !~ '^pg_toast' "
-            + ") "
-            + "UNION "
-            + "SELECT 'Total:', "
-            + "       pg_size_pretty(SUM(pg_relation_size(C.oid))), "
-            + "       SUM(pg_relation_size(C.oid)), "
-            + "       2 as ordering "
-            + "  FROM pg_class C "
-            + "  LEFT JOIN pg_namespace N ON (N.oid = C.relnamespace) "
-            + " WHERE nspname NOT IN ('pg_catalog', 'information_schema') "
-            + ") AS needed_alias_name "
-            + "ORDER BY ordering, \"Total Bytes\" DESC";
-
-String sql2 =
-        "SELECT relname AS \"Table Name\", "
-            + "pg_size_pretty(pg_total_relation_size(C.oid)) AS \"Total Size\", "
-            + "pg_total_relation_size(C.oid) AS \"Total Bytes\" "
-            + "FROM pg_class C "
-            + "LEFT JOIN pg_namespace N ON (N.oid = C.relnamespace) "
-            + "WHERE nspname NOT IN ('pg_catalog', 'information_schema') "
-            + "    AND nspname !~ '^pg_toast' "
-            + "ORDER BY pg_total_relation_size(C.oid) DESC";
-
-pageContext.setAttribute("jsonData1", ChartGenericJsonQuery.getJsonString(agencyId, sql, null, null));
-pageContext.setAttribute("jsonData2", ChartGenericJsonQuery.getJsonString(agencyId, sql2));
+pageContext.setAttribute("jsonData1", DbDiskSpaceQuery.getTotalsJson(agencyId));
+pageContext.setAttribute("jsonData2", DbDiskSpaceQuery.getDetailsJson(agencyId));
 %>
 <t:layout>
   <jsp:attribute name="title"><fmt:message key="div.ddsu" /></jsp:attribute>

--- a/transitclockWebapp/src/test/java/org/transitclock/reports/DbDiskSpaceQueryTest.java
+++ b/transitclockWebapp/src/test/java/org/transitclock/reports/DbDiskSpaceQueryTest.java
@@ -1,0 +1,72 @@
+package org.transitclock.reports;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+
+import java.sql.SQLException;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+/**
+ * Catches drift between the Postgres SQL we promise (in DbDiskSpaceQuery
+ * Javadocs) and what we actually send to ChartGenericJsonQuery — anything
+ * a future edit might silently break (toast filter, totals UNION shape,
+ * size-pretty column).
+ */
+public class DbDiskSpaceQueryTest {
+
+    private static final String AGENCY = "test-agency";
+
+    @Test
+    public void totalsJson_passesUnionedSqlWithToastFilter() throws SQLException {
+        try (MockedStatic<ChartGenericJsonQuery> chart =
+                     Mockito.mockStatic(ChartGenericJsonQuery.class)) {
+            chart.when(() -> ChartGenericJsonQuery.getJsonString(any(), any()))
+                    .thenReturn("{}");
+
+            DbDiskSpaceQuery.getTotalsJson(AGENCY);
+
+            ArgumentCaptor<String> sql = ArgumentCaptor.forClass(String.class);
+            chart.verify(() -> ChartGenericJsonQuery.getJsonString(eq(AGENCY), sql.capture()));
+            String captured = sql.getValue();
+            assertThat(captured).contains("UNION");
+            assertThat(captured).contains("'Total:'");
+            assertThat(captured).contains("nspname !~ '^pg_toast'");
+            assertThat(captured).contains("C.relkind <> 'i'");
+            assertThat(captured).contains("ORDER BY ordering");
+        }
+    }
+
+    @Test
+    public void detailsJson_passesNonUnionedSqlIncludingIndexes() throws SQLException {
+        try (MockedStatic<ChartGenericJsonQuery> chart =
+                     Mockito.mockStatic(ChartGenericJsonQuery.class)) {
+            chart.when(() -> ChartGenericJsonQuery.getJsonString(any(), any()))
+                    .thenReturn("{}");
+
+            DbDiskSpaceQuery.getDetailsJson(AGENCY);
+
+            ArgumentCaptor<String> sql = ArgumentCaptor.forClass(String.class);
+            chart.verify(() -> ChartGenericJsonQuery.getJsonString(eq(AGENCY), sql.capture()));
+            String captured = sql.getValue();
+            assertThat(captured).doesNotContain("UNION");
+            assertThat(captured).contains("nspname !~ '^pg_toast'");
+            // No relkind filter — details view keeps indexes as their own rows.
+            assertThat(captured).doesNotContain("relkind");
+        }
+    }
+
+    @Test
+    public void totalsJson_propagatesNullFromQuery() throws SQLException {
+        try (MockedStatic<ChartGenericJsonQuery> chart =
+                     Mockito.mockStatic(ChartGenericJsonQuery.class)) {
+            chart.when(() -> ChartGenericJsonQuery.getJsonString(any(), any()))
+                    .thenReturn(null);
+
+            assertThat(DbDiskSpaceQuery.getTotalsJson(AGENCY)).isNull();
+        }
+    }
+}

--- a/transitclockWebapp/src/test/java/org/transitclock/reports/DbDiskSpaceQueryTest.java
+++ b/transitclockWebapp/src/test/java/org/transitclock/reports/DbDiskSpaceQueryTest.java
@@ -41,11 +41,11 @@ public class DbDiskSpaceQueryTest {
                     // Security-relevant: dropping this filter would expose
                     // pg_catalog and information_schema tables to API clients.
                     "nspname NOT IN ('pg_catalog', 'information_schema')",
-                    // Per-row uses pg_total_relation_size; the totals row uses
-                    // pg_relation_size — different functions, swapping is a
-                    // plausible silent regression.
+                    // Per-row and total must use the SAME size function
+                    // (pg_total_relation_size = main + indexes + TOAST) so
+                    // the Total: row matches the sum of the visible rows.
                     "pg_total_relation_size(C.oid)",
-                    "SUM(pg_relation_size(C.oid))");
+                    "SUM(pg_total_relation_size(C.oid))");
         }
     }
 

--- a/transitclockWebapp/src/test/java/org/transitclock/reports/DbDiskSpaceQueryTest.java
+++ b/transitclockWebapp/src/test/java/org/transitclock/reports/DbDiskSpaceQueryTest.java
@@ -32,11 +32,20 @@ public class DbDiskSpaceQueryTest {
             ArgumentCaptor<String> sql = ArgumentCaptor.forClass(String.class);
             chart.verify(() -> ChartGenericJsonQuery.getJsonString(eq(AGENCY), sql.capture()));
             String captured = sql.getValue();
-            assertThat(captured).contains("UNION");
-            assertThat(captured).contains("'Total:'");
-            assertThat(captured).contains("nspname !~ '^pg_toast'");
-            assertThat(captured).contains("C.relkind <> 'i'");
-            assertThat(captured).contains("ORDER BY ordering");
+            assertThat(captured).contains(
+                    "UNION",
+                    "'Total:'",
+                    "nspname !~ '^pg_toast'",
+                    "C.relkind <> 'i'",
+                    "ORDER BY ordering",
+                    // Security-relevant: dropping this filter would expose
+                    // pg_catalog and information_schema tables to API clients.
+                    "nspname NOT IN ('pg_catalog', 'information_schema')",
+                    // Per-row uses pg_total_relation_size; the totals row uses
+                    // pg_relation_size — different functions, swapping is a
+                    // plausible silent regression.
+                    "pg_total_relation_size(C.oid)",
+                    "SUM(pg_relation_size(C.oid))");
         }
     }
 
@@ -53,7 +62,10 @@ public class DbDiskSpaceQueryTest {
             chart.verify(() -> ChartGenericJsonQuery.getJsonString(eq(AGENCY), sql.capture()));
             String captured = sql.getValue();
             assertThat(captured).doesNotContain("UNION");
-            assertThat(captured).contains("nspname !~ '^pg_toast'");
+            assertThat(captured).contains(
+                    "nspname !~ '^pg_toast'",
+                    "nspname NOT IN ('pg_catalog', 'information_schema')",
+                    "pg_total_relation_size(C.oid)");
             // No relkind filter — details view keeps indexes as their own rows.
             assertThat(captured).doesNotContain("relkind");
         }

--- a/transitclockWebapp/src/test/java/org/transitclock/web/api/DbDiskSpaceResourceTest.java
+++ b/transitclockWebapp/src/test/java/org/transitclock/web/api/DbDiskSpaceResourceTest.java
@@ -1,0 +1,135 @@
+package org.transitclock.web.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.ws.rs.core.Application;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import java.sql.SQLException;
+import java.util.function.Predicate;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.glassfish.jersey.test.JerseyTest;
+import org.junit.Test;
+import org.transitclock.web.api.DbDiskSpaceResource.AgencyQuery;
+
+/**
+ * In-process JerseyTest spinning DbDiskSpaceResource on a Grizzly2 HTTP
+ * container. Each test rebuilds the resource via the package-private DI
+ * constructor with stubbed query / validator fakes — the real DB and the
+ * ApiKeyManager singleton never get touched.
+ */
+public class DbDiskSpaceResourceTest extends JerseyTest {
+
+    private static final String VALID_KEY = "test-key";
+    private static final String AGENCY = "test-agency";
+
+    private AgencyQuery totalsFn = a -> "{\"totals_default\":true}";
+    private AgencyQuery detailsFn = a -> "{\"details_default\":true}";
+    private Predicate<String> apiKeyValidator = VALID_KEY::equals;
+
+    @Override
+    protected Application configure() {
+        return new ResourceConfig().register(new DbDiskSpaceResource(
+                a -> totalsFn.run(a),
+                a -> detailsFn.run(a),
+                k -> apiKeyValidator.test(k)));
+    }
+
+    private Response get(String agencyId, String apiKey) {
+        var t = target("/status/db-disk-space");
+        if (agencyId != null) t = t.queryParam("a", agencyId);
+        if (apiKey != null) t = t.queryParam("k", apiKey);
+        return t.request(MediaType.APPLICATION_JSON).get();
+    }
+
+    @Test
+    public void missingApiKey_returns401() {
+        Response r = get(AGENCY, null);
+        assertThat(r.getStatus()).isEqualTo(401);
+        assertThat(r.readEntity(String.class)).contains("Missing or invalid API key");
+    }
+
+    @Test
+    public void invalidApiKey_returns401() {
+        Response r = get(AGENCY, "bogus");
+        assertThat(r.getStatus()).isEqualTo(401);
+    }
+
+    @Test
+    public void missingAgency_returns400() {
+        Response r = get(null, VALID_KEY);
+        assertThat(r.getStatus()).isEqualTo(400);
+        assertThat(r.readEntity(String.class)).contains("query parameter 'a'");
+    }
+
+    @Test
+    public void emptyAgency_returns400() {
+        Response r = get("", VALID_KEY);
+        assertThat(r.getStatus()).isEqualTo(400);
+    }
+
+    @Test
+    public void happyPath_wrapsBothJsonsInEnvelope() {
+        totalsFn = a -> "{\"cols\":[],\"rows\":[1]}";
+        detailsFn = a -> "{\"cols\":[],\"rows\":[2,3]}";
+
+        Response r = get(AGENCY, VALID_KEY);
+
+        assertThat(r.getStatus()).isEqualTo(200);
+        assertThat(r.getMediaType().isCompatible(MediaType.APPLICATION_JSON_TYPE)).isTrue();
+        assertThat(r.readEntity(String.class))
+                .isEqualTo("{\"totals\":{\"cols\":[],\"rows\":[1]},"
+                        + "\"details\":{\"cols\":[],\"rows\":[2,3]}}");
+    }
+
+    @Test
+    public void agencyIdIsForwardedToBothQueries() {
+        var capturedTotals = new String[1];
+        var capturedDetails = new String[1];
+        totalsFn = a -> { capturedTotals[0] = a; return "1"; };
+        detailsFn = a -> { capturedDetails[0] = a; return "2"; };
+
+        get(AGENCY, VALID_KEY);
+
+        assertThat(capturedTotals[0]).isEqualTo(AGENCY);
+        assertThat(capturedDetails[0]).isEqualTo(AGENCY);
+    }
+
+    @Test
+    public void nullQueryResults_emitJsonNull() {
+        totalsFn = a -> null;
+        detailsFn = a -> null;
+
+        Response r = get(AGENCY, VALID_KEY);
+
+        assertThat(r.getStatus()).isEqualTo(200);
+        assertThat(r.readEntity(String.class))
+                .isEqualTo("{\"totals\":null,\"details\":null}");
+    }
+
+    @Test
+    public void sqlException_returnsSanitized500() {
+        totalsFn = a -> { throw new SQLException("relation \"secrets\" does not exist"); };
+
+        Response r = get(AGENCY, VALID_KEY);
+
+        assertThat(r.getStatus()).isEqualTo(500);
+        String body = r.readEntity(String.class);
+        assertThat(body).isEqualTo("Database query failed; see server logs.");
+        // Critical: don't leak the raw Postgres error text to clients.
+        assertThat(body).doesNotContain("secrets");
+        assertThat(body).doesNotContain("relation");
+    }
+
+    @Test
+    public void runtimeException_returnsSanitized500() {
+        totalsFn = a -> { throw new IllegalStateException("connection pool exhausted: 30/30"); };
+
+        Response r = get(AGENCY, VALID_KEY);
+
+        assertThat(r.getStatus()).isEqualTo(500);
+        String body = r.readEntity(String.class);
+        assertThat(body).isEqualTo("Database query failed; see server logs.");
+        assertThat(body).doesNotContain("connection pool");
+    }
+}

--- a/transitclockWebapp/src/test/java/org/transitclock/web/api/DbDiskSpaceResourceTest.java
+++ b/transitclockWebapp/src/test/java/org/transitclock/web/api/DbDiskSpaceResourceTest.java
@@ -1,7 +1,9 @@
 package org.transitclock.web.api;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.ws.rs.core.Application;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
@@ -29,6 +31,11 @@ public class DbDiskSpaceResourceTest extends JerseyTest {
 
     @Override
     protected Application configure() {
+        // Wrapper lambdas — NOT method references — so each request re-reads
+        // the mutable fields. Tests reassign them in-body to vary behavior;
+        // collapsing to (totalsFn::run, detailsFn::run, apiKeyValidator::test)
+        // would bind the field values once at configure() time and lose the
+        // late binding.
         return new ResourceConfig().register(new DbDiskSpaceResource(
                 a -> totalsFn.run(a),
                 a -> detailsFn.run(a),
@@ -69,7 +76,7 @@ public class DbDiskSpaceResourceTest extends JerseyTest {
     }
 
     @Test
-    public void happyPath_wrapsBothJsonsInEnvelope() {
+    public void happyPath_wrapsBothJsonsInEnvelope() throws Exception {
         totalsFn = a -> "{\"cols\":[],\"rows\":[1]}";
         detailsFn = a -> "{\"cols\":[],\"rows\":[2,3]}";
 
@@ -77,9 +84,37 @@ public class DbDiskSpaceResourceTest extends JerseyTest {
 
         assertThat(r.getStatus()).isEqualTo(200);
         assertThat(r.getMediaType().isCompatible(MediaType.APPLICATION_JSON_TYPE)).isTrue();
+        String body = r.readEntity(String.class);
+        assertThat(body).isEqualTo("{\"totals\":{\"cols\":[],\"rows\":[1]},"
+                + "\"details\":{\"cols\":[],\"rows\":[2,3]}}");
+        // Locks the invariant the raw-string-concat in DbDiskSpaceResource
+        // promises — if the upstream contract ever returns non-JSON, the
+        // envelope is no longer parseable and this fails loudly.
+        new ObjectMapper().readTree(body);
+    }
+
+    @Test
+    public void totalsNullDetailsPresent_emitsMixedEnvelope() {
+        totalsFn = a -> null;
+        detailsFn = a -> "{\"x\":1}";
+
+        Response r = get(AGENCY, VALID_KEY);
+
+        assertThat(r.getStatus()).isEqualTo(200);
         assertThat(r.readEntity(String.class))
-                .isEqualTo("{\"totals\":{\"cols\":[],\"rows\":[1]},"
-                        + "\"details\":{\"cols\":[],\"rows\":[2,3]}}");
+                .isEqualTo("{\"totals\":null,\"details\":{\"x\":1}}");
+    }
+
+    @Test
+    public void totalsPresentDetailsNull_emitsMixedEnvelope() {
+        totalsFn = a -> "{\"x\":1}";
+        detailsFn = a -> null;
+
+        Response r = get(AGENCY, VALID_KEY);
+
+        assertThat(r.getStatus()).isEqualTo(200);
+        assertThat(r.readEntity(String.class))
+                .isEqualTo("{\"totals\":{\"x\":1},\"details\":null}");
     }
 
     @Test
@@ -117,8 +152,7 @@ public class DbDiskSpaceResourceTest extends JerseyTest {
         String body = r.readEntity(String.class);
         assertThat(body).isEqualTo("Database query failed; see server logs.");
         // Critical: don't leak the raw Postgres error text to clients.
-        assertThat(body).doesNotContain("secrets");
-        assertThat(body).doesNotContain("relation");
+        assertThat(body).doesNotContain("secrets", "relation");
     }
 
     @Test
@@ -131,5 +165,28 @@ public class DbDiskSpaceResourceTest extends JerseyTest {
         String body = r.readEntity(String.class);
         assertThat(body).isEqualTo("Database query failed; see server logs.");
         assertThat(body).doesNotContain("connection pool");
+    }
+
+    @Test
+    public void detailsException_returnsSanitized500() {
+        // Mirrors sqlException_ but throws from detailsFn, so a future refactor
+        // that only wraps the totals call (or reorders them) gets caught.
+        detailsFn = a -> { throw new SQLException("password=hunter2 in error string"); };
+
+        Response r = get(AGENCY, VALID_KEY);
+
+        assertThat(r.getStatus()).isEqualTo(500);
+        String body = r.readEntity(String.class);
+        assertThat(body).isEqualTo("Database query failed; see server logs.");
+        assertThat(body).doesNotContain("password", "hunter2");
+    }
+
+    @Test
+    public void defaultConstructor_doesNotThrow() {
+        // Catches accidental swaps in the production no-arg wiring
+        // (e.g. getTotalsJson <-> getDetailsJson method-ref typo).
+        // The lambdas don't fire here, just get stored, so this is safe
+        // even though ApiKeyManager.getInstance() is DB-backed.
+        assertThatNoException().isThrownBy(DbDiskSpaceResource::new);
     }
 }


### PR DESCRIPTION
## Summary

- Bootstraps Jersey 3.1.7 inside `transitclockWebapp` at `@ApplicationPath("api")` — distinct from `transitclockApi`'s `/v1/*` surface. This is the first JAX-RS resource in the webapp module; future webapp-internal JSON endpoints (ones that talk to the DB directly rather than to Core via RMI) live alongside it.
- Adds `GET /api/status/db-disk-space?a=<agency>&k=<apiKey>` returning `{"totals": …, "details": …}` (Google Charts DataTable JSON for both). Auth uses `ApiKeyManager.getInstance().isKeyValid(...)` — the same key namespace `transitclockApi` uses.
- Extracts the Postgres catalog SQL out of `status/dbDiskSpace.jsp` into `DbDiskSpaceQuery`, used by both the JSP (server-side render, unauthenticated like before) and the new REST endpoint (auth-gated for external clients).

## Pom subtleties (documented inline)

- **Excluded** the pre-Jakarta Jersey 2.11 jars that `transitclockTraccarClient` drags in transitively. Their SPI-registered `DefaultJacksonJaxbJsonProvider` gets picked up by Jersey 3.1's package scan at servlet init and crashes against the existing Jackson 2.8.9 chain (missing `JacksonFeature` class).
- **Did not** pull in `jersey-media-json-jackson`. Its jackson-databind 2.17.x bump breaks Hibernate's `JacksonIntegration` static init. The endpoint returns a pre-serialized JSON `String` wrapped in `Response.ok(...).type(APPLICATION_JSON)`, no marshalling needed.

## Pre-existing issues surfaced (not fixed in this PR)

- **JSP null-handling regression risk in `dbDiskSpace.jsp`**: when `ChartGenericJsonQuery.getJsonString` returns `null` (zero-row query), the JSP renders `var jsonData = ;` — a JS syntax error that blanks the page. Same bug existed before this refactor; the new REST endpoint handles it correctly. Worth a follow-up to coalesce in the JSP.
- **`ApiKeyManager.isKeyValid` swallows all exceptions and returns `false`**: a DB outage during key lookup surfaces as a misleading 401 "invalid key" to the client. Pre-existing, lives in `transitclockCore`.
- **`GenericQuery.connection` is a `static` field** never closed. Concurrent requests race on a single shared JDBC `Connection` and leak one per request. Predates this PR; the new endpoint exercises the same code path the JSP and other report queries already use, so blast radius is unchanged. Should be a separate fix.

## Test plan

- [x] `mvn -pl transitclockWebapp -am package -DskipTests` builds cleanly
- [x] Tomcat 11 (docker dev stack) accepts the WAR; JSP welcome page returns 200 (regression check that the Jersey deps don't break the existing JSP/Hibernate stack)
- [x] `GET /api/status/db-disk-space?a=1` (no key) → 401
- [x] `GET /api/status/db-disk-space?a=1&k=bogus` (bad key) → 401
- [x] `GET /api/status/db-disk-space?k=$VALID_KEY` (no agency) → 400
- [x] `GET /api/status/db-disk-space?a=1&k=$VALID_KEY` → 200 with `{"totals": {...}, "details": {...}}`; verified column labels and that the `Total:` row is pinned at the bottom of `totals.rows`
- [x] `GET /api/status/db-disk-space?a=does-not-exist&k=$VALID_KEY` → 500 with sanitized body `"Database query failed; see server logs."`; full stack including `agency=does-not-exist` lands in the Tomcat log
- [x] `GET /web/status/dbDiskSpace.jsp?a=1` (the JSP, post-refactor) still renders the inline chart JSON server-side

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a protected JSON API endpoint exposing database disk-space totals and per-table details (API key required).

* **Refactor**
  * Centralized disk-space SQL/JSON logic into a reusable query utility; status page now consumes its outputs.

* **Tests**
  * Added unit and in-process integration tests for SQL generation, API parameter validation, success/error responses, null handling, and sanitized 500 responses.

* **Chores**
  * Pinned and adjusted webapp dependencies and expanded the test toolchain to support the new API layer and avoid compatibility issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->