### PR TITLE
Add Dashboard page as first per-agency sidebar entry

### DIFF
--- a/transitclockWebapp/src/main/java/org/transitclock/reports/DbDiskSpaceQuery.java
+++ b/transitclockWebapp/src/main/java/org/transitclock/reports/DbDiskSpaceQuery.java
@@ -1,13 +1,13 @@
 package org.transitclock.reports;
 
 import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+import org.transitclock.db.GenericQuery;
 
 /**
- * Postgres-catalog queries for per-table on-disk size, returned as
- * Google Charts DataTable JSON. Used by status/dbDiskSpace.jsp (server-side
- * render) and by the JAX-RS endpoint at /api/status/db-disk-space (external
- * authorized clients). Centralized here so the SQL doesn't drift between
- * the two callers.
+ * Single source of truth for per-table on-disk-size SQL. Centralized so the
+ * chart, dashboard, and API callers can't drift out of sync on filters.
  */
 public final class DbDiskSpaceQuery {
 
@@ -58,6 +58,22 @@ public final class DbDiskSpaceQuery {
                     + "    AND nspname !~ '^pg_toast' "
                     + "ORDER BY pg_total_relation_size(C.oid) DESC";
 
+    // Filters must mirror TOTALS_SQL's inner SELECT so the dashboard bar
+    // chart and the dbDiskSpace page report the same per-table sizes.
+    // LIMIT is appended at runtime from a clamped int.
+    private static final String TOP_TABLES_SQL =
+            "SELECT relname, "
+                    + "pg_size_pretty(pg_total_relation_size(C.oid)) AS total_size, "
+                    + "pg_total_relation_size(C.oid) AS total_bytes "
+                    + "FROM pg_class C "
+                    + "LEFT JOIN pg_namespace N ON (N.oid = C.relnamespace) "
+                    + "WHERE nspname NOT IN ('pg_catalog', 'information_schema') "
+                    + "    AND C.relkind <> 'i' "
+                    + "    AND nspname !~ '^pg_toast' "
+                    + "ORDER BY pg_total_relation_size(C.oid) DESC";
+
+    public record TableSize(String tableName, String prettySize, long bytes) {}
+
     private DbDiskSpaceQuery() {}
 
     public static String getTotalsJson(String agencyId) throws SQLException {
@@ -66,5 +82,38 @@ public final class DbDiskSpaceQuery {
 
     public static String getDetailsJson(String agencyId) throws SQLException {
         return ChartGenericJsonQuery.getJsonString(agencyId, DETAILS_SQL);
+    }
+
+    /**
+     * Top-N largest user tables by on-disk size, biggest first. Limit is
+     * clamped to [1, 1000] before being inlined into the SQL — the value is
+     * caller-supplied but never user-controlled; the clamp guards against
+     * accidental zero/negative or absurd page sizes.
+     */
+    public static List<TableSize> getTopTables(String agencyId, int limit) throws SQLException {
+        int clamped = Math.max(1, Math.min(limit, 1000));
+        return TopTablesQuery.run(agencyId, TOP_TABLES_SQL + " LIMIT " + clamped);
+    }
+
+    private static final class TopTablesQuery extends GenericQuery {
+        private final List<TableSize> rows = new ArrayList<>();
+
+        private TopTablesQuery(String agencyId) throws SQLException {
+            super(agencyId);
+        }
+
+        static List<TableSize> run(String agencyId, String sql) throws SQLException {
+            TopTablesQuery q = new TopTablesQuery(agencyId);
+            q.doQuery(sql);
+            return q.rows;
+        }
+
+        @Override
+        protected void addRow(List<Object> values) {
+            String name = String.valueOf(values.get(0));
+            String pretty = String.valueOf(values.get(1));
+            long bytes = ((Number) values.get(2)).longValue();
+            rows.add(new TableSize(name, pretty, bytes));
+        }
     }
 }

--- a/transitclockWebapp/src/main/resources/org/transitclock/i18n/text.properties
+++ b/transitclockWebapp/src/main/resources/org/transitclock/i18n/text.properties
@@ -1,5 +1,6 @@
 hello.label.welcome = Welcome
 div.agencies = Agencies
+div.dashboard = Dashboard
 div.maps = Maps
 div.reports = Reports
 div.api = Api

--- a/transitclockWebapp/src/main/resources/org/transitclock/i18n/text_pl.properties
+++ b/transitclockWebapp/src/main/resources/org/transitclock/i18n/text_pl.properties
@@ -1,5 +1,6 @@
 hello.label.welcome = Witaj
 div.agencies = Agencje
+div.dashboard = Pulpit
 div.maps = Mapy
 div.reports = Raporty
 div.api = Api

--- a/transitclockWebapp/src/main/webapp/WEB-INF/tags/activeBlocksSummary.tag
+++ b/transitclockWebapp/src/main/webapp/WEB-INF/tags/activeBlocksSummary.tag
@@ -1,0 +1,44 @@
+<%@ tag pageEncoding="UTF-8" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
+<%-- The five-stat strip shown on /status/activeBlocks.jsp and /dashboard.
+     Both pages mount the active-blocks Stimulus controller; the data-field
+     names here are the controller's #renderSummary contract. Keep that
+     contract here in one place so callers can't drift. --%>
+<div data-active-blocks-target="summary"
+     class="flex items-stretch bg-white border border-gray-200 rounded-lg overflow-hidden shadow-[0_1px_2px_rgba(0,0,0,0.03)]">
+  <div class="flex-1 min-w-0 px-4 py-3 border-r border-gray-200">
+    <div class="text-[11px] font-semibold uppercase tracking-wider text-gray-500"><fmt:message key="div.blocks"/></div>
+    <div class="flex items-baseline gap-1.5 mt-0.5">
+      <span data-field="total-blocks" class="text-[22px] font-bold tabular-nums text-gray-900">—</span>
+      <span class="text-xs text-gray-500 font-medium">total</span>
+    </div>
+  </div>
+  <div class="flex-1 min-w-0 px-4 py-3 border-r border-gray-200">
+    <div class="text-[11px] font-semibold uppercase tracking-wider text-gray-500"><fmt:message key="div.assigned"/></div>
+    <div class="flex items-baseline gap-1.5 mt-0.5">
+      <span data-field="percent-assigned" class="text-[22px] font-bold tabular-nums text-brand-accent">—</span>
+      <span data-field="assigned-detail" class="text-xs text-gray-500 font-medium tabular-nums"></span>
+    </div>
+  </div>
+  <div class="flex-1 min-w-0 px-4 py-3 border-r border-gray-200">
+    <div class="text-[11px] font-semibold uppercase tracking-wider text-gray-500"><fmt:message key="div.contime"/></div>
+    <div class="flex items-baseline gap-1.5 mt-0.5">
+      <span data-field="percent-on-time" class="text-[22px] font-bold tabular-nums text-status-on-time-ink">—</span>
+      <span data-field="on-time-count" class="text-xs text-gray-500 font-medium tabular-nums"></span>
+    </div>
+  </div>
+  <div class="flex-1 min-w-0 px-4 py-3 border-r border-gray-200">
+    <div class="text-[11px] font-semibold uppercase tracking-wider text-gray-500"><fmt:message key="div.clate"/></div>
+    <div class="flex items-baseline gap-1.5 mt-0.5">
+      <span data-field="percent-late" class="text-[22px] font-bold tabular-nums text-status-late">—</span>
+      <span data-field="late-count" class="text-xs text-gray-500 font-medium tabular-nums"></span>
+    </div>
+  </div>
+  <div class="flex-1 min-w-0 px-4 py-3">
+    <div class="text-[11px] font-semibold uppercase tracking-wider text-gray-500"><fmt:message key="div.cearly"/></div>
+    <div class="flex items-baseline gap-1.5 mt-0.5">
+      <span data-field="percent-early" class="text-[22px] font-bold tabular-nums text-status-early">—</span>
+      <span data-field="early-count" class="text-xs text-gray-500 font-medium tabular-nums"></span>
+    </div>
+  </div>
+</div>

--- a/transitclockWebapp/src/main/webapp/WEB-INF/tags/layout.tag
+++ b/transitclockWebapp/src/main/webapp/WEB-INF/tags/layout.tag
@@ -33,6 +33,7 @@
 <%-- Any /reports/* page (except the API calls section) keeps the
      Reports nav highlighted so subpages don't appear unrooted. --%>
 <c:set var="onReports"      value="${fn:startsWith(path, '/reports/') and not onApi}"/>
+<c:set var="onDashboard"     value="${path == '/dashboard/index.jsp'}"/>
 <c:set var="onActiveBlocks" value="${path == '/status/activeBlocks.jsp'}"/>
 <c:set var="onServerStatus" value="${path == '/status/serverStatus.jsp'}"/>
 <c:set var="onDbDiskSpace"  value="${path == '/status/dbDiskSpace.jsp'}"/>
@@ -97,6 +98,7 @@
           <c:set var="mapsExpanded"       value="${mapForActive or mapInclActive or schAdhMapActive}"/>
           <c:set var="reportsActive"      value="${onReports and agencyMatch}"/>
           <c:set var="apiActive"          value="${onApi and agencyMatch}"/>
+          <c:set var="dashboardActive"    value="${onDashboard and agencyMatch}"/>
           <c:set var="activeBlocksActive" value="${onActiveBlocks and agencyMatch}"/>
           <c:set var="serverStatusActive" value="${onServerStatus and agencyMatch}"/>
           <c:set var="dbDiskSpaceActive"  value="${onDbDiskSpace and agencyMatch}"/>
@@ -105,6 +107,13 @@
           <div>
             <h3 class="px-2.5 mb-2 text-[11px] font-bold tracking-[0.08em] uppercase text-gray-500"><c:out value="${agency.agencyName}"/></h3>
             <ul class="space-y-0.5">
+              <li>
+                <a class="${navBase} ${dashboardActive ? navActive : navInactive}" <c:if test="${dashboardActive}">aria-current="page"</c:if> href="${ctx}/dashboard/index.jsp${qs}">
+                  <c:if test="${dashboardActive}"><span class="absolute left-0 top-1.5 bottom-1.5 w-[3px] rounded-r-sm bg-brand-accent"></span></c:if>
+                  <svg class="size-4 ${dashboardActive ? iconActive : iconIdle}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="3" width="7" height="9" rx="1"/><rect x="14" y="3" width="7" height="5" rx="1"/><rect x="14" y="12" width="7" height="9" rx="1"/><rect x="3" y="16" width="7" height="5" rx="1"/></svg>
+                  <fmt:message key="div.dashboard"/>
+                </a>
+              </li>
               <li data-controller="disclosure">
                 <button type="button" aria-expanded="${mapsExpanded}"
                         data-action="click->disclosure#toggle"

--- a/transitclockWebapp/src/main/webapp/WEB-INF/tags/serverStatusGrid.tag
+++ b/transitclockWebapp/src/main/webapp/WEB-INF/tags/serverStatusGrid.tag
@@ -1,0 +1,43 @@
+<%@ tag pageEncoding="UTF-8" %>
+<%@ taglib prefix="c"   uri="jakarta.tags.core" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
+<%@ attribute name="monitorResults" required="false" type="java.util.List" %>
+<%@ attribute name="error"          required="false" %>
+<c:choose>
+  <c:when test="${not empty error}">
+    <div class="rounded-lg border border-red-200 bg-red-50 p-4">
+      <h3 class="text-sm font-semibold text-red-900"><fmt:message key="div.coreUnreachable"/></h3>
+      <p class="mt-1 text-sm text-red-800 font-mono break-all"><c:out value="${error}"/></p>
+    </div>
+  </c:when>
+  <c:otherwise>
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+      <c:forEach var="monitorResult" items="${monitorResults}">
+        <c:if test="${not empty monitorResult.message}">
+          <article class="bg-white border border-gray-200 rounded-lg p-4">
+            <h3 class="text-xs font-semibold uppercase tracking-wider text-gray-500">
+              <c:out value="${monitorResult.type}"/>
+            </h3>
+            <c:choose>
+              <c:when test="${not empty monitorResult.stats}">
+                <dl class="mt-3 grid grid-cols-2 gap-x-4 gap-y-1.5 text-sm">
+                  <c:forEach var="stat" items="${monitorResult.stats}">
+                    <div class="flex items-baseline gap-1.5 col-span-2 sm:col-span-1">
+                      <dt class="text-gray-500"><c:out value="${stat.key}"/>:</dt>
+                      <dd class="font-mono text-gray-900"><c:out value="${stat.value}"/></dd>
+                    </div>
+                  </c:forEach>
+                </dl>
+              </c:when>
+              <c:otherwise>
+                <p class="mt-2 text-sm text-gray-900 leading-relaxed tabular-nums">
+                  <c:out value="${monitorResult.message}"/>
+                </p>
+              </c:otherwise>
+            </c:choose>
+          </article>
+        </c:if>
+      </c:forEach>
+    </div>
+  </c:otherwise>
+</c:choose>

--- a/transitclockWebapp/src/main/webapp/css/general.css
+++ b/transitclockWebapp/src/main/webapp/css/general.css
@@ -2,56 +2,6 @@
 /*
  * This file contains general CSS config for TheTransitClock pages
  */
-body {
-	font-family: sans-serif;
-	font-size: large;
-	margin: 0px 0px 10px 0px;
-}
-
-#mainDiv {
-	margin-left: auto;
-	margin-right: auto;
-	width: 700px;
-}
-
-#title {
-	margin-top: 40px;
-	margin-bottom: 2px;
-	font-weight: normal;
-	font-size: xx-large;
-	text-align: center;
-}
-
-#subtitle {
-	text-align: center;
-	font-size: x-large;
-}
-
-/* For list of choices to be centered in page, e.g. list of reports
- */
-.choicesList {
-	width: 350px;
-	margin-left: auto;
-	margin-right: auto;
-	line-height: 125%;
-	margin-top: 5px;
-}
-
-.ui-tooltip {
-	/* Change background color of tooltips a bit and use a reasonable font size */
-	background: #faf7f1;
-	font-size: small;
-	padding: 4px;
-}
-
-/* Pre-Tailwind input chrome. Scoped to .param so it doesn't bleed onto
-   .form-control or partials that have already migrated to Tailwind
-   (jsonXmlFormat.jsp, submitApiCall.jsp). /reports/apiCalls/* pages
-   render hybrid until they're fully ported. */
-.param > input, .param > select {
-	background-color: #f8f8f8;
-	font-size: large;
-}
 
 .form-control {
 	display: block;
@@ -86,39 +36,5 @@ select.form-control:not([multiple]) {
 	background-repeat: no-repeat;
 	background-size: 1.25em 1.25em;
 	padding-right: 2.5rem;
-}
-
-.earlyColor {
-	background: #f2b7cd;
-	border-radius: 4px; 
-}
-
-.lateColor {
-	background: #fbfd97;
-	border-radius: 4px; 
-}
-
-.problemColor {
-	background: #f2b7cd;
-	border-radius: 4px;
-}
-
-/* For tables showing data in reports */
-#dataTable {
-	margin-left: auto;
- 	margin-right: auto;
-}
-
-#dataTable, #dataTable th, #dataTable td {
- border: 1px solid #BBB;
- border-collapse: collapse;
-}
-
-#dataTable th, #dataTable td {
-    padding: 2px 10px;
-}
-
-#dataTable th, #dataTable thead {
-  background: #ddd;
 }
 

--- a/transitclockWebapp/src/main/webapp/dashboard/index.jsp
+++ b/transitclockWebapp/src/main/webapp/dashboard/index.jsp
@@ -1,0 +1,174 @@
+<%@ page contentType="text/html;charset=UTF-8" pageEncoding="UTF-8" %>
+<%@ page import="org.transitclock.db.webstructs.WebAgency" %>
+<%@ page import="org.transitclock.ipc.clients.ServerStatusInterfaceFactory" %>
+<%@ page import="org.transitclock.monitoring.MonitorResult" %>
+<%@ page import="org.transitclock.reports.DbDiskSpaceQuery" %>
+<%@ page import="org.transitclock.reports.ScheduleAdherenceController" %>
+<%@ page import="org.transitclock.utils.Time" %>
+<%@ page import="java.util.Date" %>
+<%@ page import="java.util.List" %>
+<%
+String agencyId = request.getParameter("a");
+if (agencyId == null || agencyId.isEmpty()) {
+    response.getWriter().write("You must specify agency in query string (e.g. ?a=mbta)");
+    return;
+}
+
+int scheduleEarlySec = ScheduleAdherenceController.getScheduleEarlySeconds();
+int scheduleLateSec  = ScheduleAdherenceController.getScheduleLateSeconds();
+pageContext.setAttribute("agencyId",   agencyId);
+pageContext.setAttribute("agencyName", WebAgency.getCachedWebAgency(agencyId).getAgencyName());
+pageContext.setAttribute("now",        Time.timeStrNoTimeZone(new Date()));
+pageContext.setAttribute("earlyMsec",  scheduleEarlySec * -1000);
+pageContext.setAttribute("lateMsec",   scheduleLateSec  * 1000);
+
+List<MonitorResult> monitorResults = null;
+String monitorError = null;
+try {
+    monitorResults = ServerStatusInterfaceFactory.get(agencyId).get().getMonitorResults();
+} catch (Exception e) {
+    application.log("dashboard could not reach Core for agency=" + agencyId, e);
+    StringBuilder detail = new StringBuilder(String.valueOf(e));
+    for (Throwable cause = e.getCause(); cause != null; cause = cause.getCause())
+        detail.append(" -> ").append(cause);
+    monitorError = detail.toString();
+}
+pageContext.setAttribute("monitorResults", monitorResults);
+pageContext.setAttribute("monitorError",   monitorError);
+
+List<DbDiskSpaceQuery.TableSize> topTables = null;
+String dbError = null;
+long maxBytes = 0L;
+try {
+    topTables = DbDiskSpaceQuery.getTopTables(agencyId, 5);
+    for (DbDiskSpaceQuery.TableSize t : topTables) maxBytes = Math.max(maxBytes, t.bytes());
+} catch (java.sql.SQLException e) {
+    application.log("dashboard could not load db disk space for agency=" + agencyId, e);
+    StringBuilder detail = new StringBuilder(String.valueOf(e));
+    for (Throwable cause = e.getCause(); cause != null; cause = cause.getCause())
+        detail.append(" -> ").append(cause);
+    dbError = detail.toString();
+}
+pageContext.setAttribute("topTables", topTables);
+pageContext.setAttribute("maxBytes",  maxBytes);
+pageContext.setAttribute("dbError",   dbError);
+%>
+<t:layout>
+  <jsp:attribute name="title"><fmt:message key="div.dashboard"/></jsp:attribute>
+  <jsp:body>
+
+<div class="mb-6">
+  <h1 class="text-2xl font-bold tracking-tight text-gray-900 m-0"><fmt:message key="div.dashboard"/></h1>
+  <p class="mt-1 text-sm text-gray-500 m-0">Live overview of fleet status and system health for <c:out value="${agencyName}"/>.</p>
+</div>
+
+<div class="space-y-8">
+
+  <section data-controller="active-blocks"
+           data-active-blocks-early-msec-value="${earlyMsec}"
+           data-active-blocks-late-msec-value="${lateMsec}">
+    <div class="flex items-end justify-between gap-4 flex-wrap mb-4">
+      <div>
+        <h2 class="text-lg font-bold tracking-tight text-gray-900 m-0"><fmt:message key="div.acbiveblock"/></h2>
+        <p class="mt-1 text-sm text-gray-500 m-0">Real-time status of vehicle assignments across the fleet.</p>
+      </div>
+      <div class="flex items-center gap-3">
+        <span class="text-xs text-gray-500 inline-flex items-center gap-1.5">
+          <svg class="size-3 text-gray-500" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 2"/></svg>
+          <fmt:message key="div.AsOf"/>
+          <span data-active-blocks-target="asOf" class="font-semibold text-gray-700 tabular-nums">—</span>
+        </span>
+        <a href="${pageContext.request.contextPath}/status/activeBlocks.jsp?a=${agencyId}"
+           class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium text-gray-700 bg-white border border-gray-300 hover:bg-gray-50">
+          View details &rarr;
+        </a>
+      </div>
+    </div>
+    <t:activeBlocksSummary/>
+  </section>
+
+  <section>
+    <div class="flex items-end justify-between gap-4 flex-wrap mb-4">
+      <div>
+        <h2 class="text-lg font-bold tracking-tight text-gray-900 m-0"><fmt:message key="div.ssf"/> <c:out value="${agencyName}"/></h2>
+      </div>
+      <div class="flex items-center gap-3">
+        <span class="text-xs text-gray-500 inline-flex items-center gap-1.5">
+          <fmt:message key="div.AsOf"/>
+          <span class="font-mono text-gray-700 tabular-nums">${now}</span>
+        </span>
+        <a href="${pageContext.request.contextPath}/status/serverStatus.jsp?a=${agencyId}"
+           class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium text-gray-700 bg-white border border-gray-300 hover:bg-gray-50">
+          View details &rarr;
+        </a>
+      </div>
+    </div>
+    <t:serverStatusGrid monitorResults="${monitorResults}" error="${monitorError}"/>
+  </section>
+
+  <section>
+    <div class="flex items-end justify-between gap-4 flex-wrap mb-4">
+      <div>
+        <h2 class="text-lg font-bold tracking-tight text-gray-900 m-0"><fmt:message key="div.ddsflt"/></h2>
+        <p class="mt-1 text-sm text-gray-500 m-0">The five tables consuming the most on-disk space.</p>
+      </div>
+      <a href="${pageContext.request.contextPath}/status/dbDiskSpace.jsp?a=${agencyId}"
+         class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium text-gray-700 bg-white border border-gray-300 hover:bg-gray-50">
+        View details &rarr;
+      </a>
+    </div>
+    <c:choose>
+      <c:when test="${not empty dbError}">
+        <div class="rounded-lg border border-red-200 bg-red-50 p-4">
+          <h3 class="text-sm font-semibold text-red-900">Database query failed</h3>
+          <p class="mt-1 text-sm text-red-800 font-mono break-all"><c:out value="${dbError}"/></p>
+        </div>
+      </c:when>
+      <c:when test="${empty topTables}">
+        <div class="rounded-lg border border-gray-200 bg-white p-4 text-sm text-gray-500">No table size data available.</div>
+      </c:when>
+      <c:otherwise>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-6 bg-white border border-gray-200 rounded-lg p-5 shadow-[0_1px_2px_rgba(0,0,0,0.03)]">
+          <ul class="space-y-3 m-0 p-0 list-none">
+            <c:forEach var="t" items="${topTables}">
+              <li>
+                <div class="flex items-baseline justify-between gap-3 mb-1 text-xs">
+                  <span class="font-mono text-gray-900 truncate" title="${t.tableName}"><c:out value="${t.tableName}"/></span>
+                  <span class="text-gray-500 font-mono tabular-nums shrink-0"><c:out value="${t.prettySize}"/></span>
+                </div>
+                <div class="h-2 rounded-full bg-gray-100 overflow-hidden">
+                  <div class="h-full bg-brand-accent rounded-full" style="width: ${(t.bytes * 100.0) / maxBytes}%"></div>
+                </div>
+              </li>
+            </c:forEach>
+          </ul>
+          <div class="overflow-x-auto">
+            <table class="w-full text-sm">
+              <thead>
+                <tr class="border-b border-gray-200 text-left">
+                  <th class="py-2 pr-3 font-semibold text-gray-700 text-xs uppercase tracking-wider">Table</th>
+                  <th class="py-2 px-3 font-semibold text-gray-700 text-xs uppercase tracking-wider text-right">Size</th>
+                  <th class="py-2 pl-3 font-semibold text-gray-700 text-xs uppercase tracking-wider text-right">Bytes</th>
+                </tr>
+              </thead>
+              <tbody>
+                <c:forEach var="t" items="${topTables}">
+                  <tr class="border-b border-gray-100 last:border-b-0">
+                    <td class="py-2 pr-3 font-mono text-gray-900 break-all"><c:out value="${t.tableName}"/></td>
+                    <td class="py-2 px-3 font-mono text-gray-700 text-right tabular-nums whitespace-nowrap"><c:out value="${t.prettySize}"/></td>
+                    <td class="py-2 pl-3 font-mono text-gray-500 text-right tabular-nums whitespace-nowrap">
+                      <fmt:formatNumber value="${t.bytes}" pattern="#,###"/>
+                    </td>
+                  </tr>
+                </c:forEach>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </c:otherwise>
+    </c:choose>
+  </section>
+
+</div>
+  </jsp:body>
+</t:layout>

--- a/transitclockWebapp/src/main/webapp/javascript/controllers/active_blocks_controller.js
+++ b/transitclockWebapp/src/main/webapp/javascript/controllers/active_blocks_controller.js
@@ -23,7 +23,9 @@ export default class extends Controller {
   };
 
   connect() {
-    this.#fetchRoutes();
+    // The dashboard mounts this controller for the summary strip only; the
+    // accordion/template targets only exist on the full Active Blocks page.
+    if (this.hasAccordionTarget && this.hasRouteTemplateTarget) this.#fetchRoutes();
     this.#fetchSummary();
     this.summaryTimer = setInterval(() => this.#fetchSummary(), SUMMARY_REFRESH_MS);
   }

--- a/transitclockWebapp/src/main/webapp/reports/apiCalls/index.jsp
+++ b/transitclockWebapp/src/main/webapp/reports/apiCalls/index.jsp
@@ -8,99 +8,97 @@ if (agencyId == null || agencyId.isEmpty()) {
 pageContext.setAttribute("agencyId", agencyId);
 pageContext.setAttribute("agencyName", WebAgency.getCachedWebAgency(agencyId).getAgencyName());
 %>
+
 <t:layout>
   <jsp:attribute name="title"><fmt:message key="div.apicalls" /></jsp:attribute>
   <jsp:body>
-<div id="mainDiv">
-<div id="title"><fmt:message key="div.apicallsfor" />${agencyName}</div>
-<div id="subtitle" style="margin-bottom: 20px;"><fmt:message key="div.notethisis" /></div>
-<div id="subtitle"><fmt:message key="div.asac" /></div>
-<ul class="choicesList">
-  <li><a href="routeApiParams.jsp?a=${agencyId}"
-    title="Summary data for all routes, listed in order. Useful for creating a UI selector for routes.">
-      <fmt:message key="div.rou" /></a></li>
-  <li><a href="routeDetailsApiParams.jsp?a=${agencyId}"
-    title="Detailed data for selected routes. Includes stop and path information needed to show route on map.">
-      <fmt:message key="div.roude" /></a></li>
+    <div id="title"><fmt:message key="div.apicallsfor" />${agencyName}</div>
+    <div id="subtitle" style="margin-bottom: 20px;"><fmt:message key="div.notethisis" /></div>
+    <div id="subtitle"><fmt:message key="div.asac" /></div>
+    <ul class="list-disc list-outside pl-4">
+      <li><a href="routeApiParams.jsp?a=${agencyId}"
+        title="Summary data for all routes, listed in order. Useful for creating a UI selector for routes.">
+          <fmt:message key="div.rou" /></a></li>
+      <li><a href="routeDetailsApiParams.jsp?a=${agencyId}"
+        title="Detailed data for selected routes. Includes stop and path information needed to show route on map.">
+          <fmt:message key="div.roude" /></a></li>
 
-  <li><a href="vehiclesApiParams.jsp?a=${agencyId}"
-    title="Data for vehicles, including GPS info, for a route. Useful for showing location of vehicles on map.">
-      <fmt:message key="div.veh" /></a></li>
-  <li><a href="vehiclesDetailsApiParams.jsp?a=${agencyId}"
-    title="Detailed data for vehicles, including GPS info, for a route. Contains additional data such as schedule adherence and assignment information.">
-      <fmt:message key="div.vd" /></a></li>
-  <li><a href="vehicleConfigsApiParams.jsp?a=${agencyId}"
-    title="Configuration data for vehicles. A way of getting list of vehicles configured for agency.">
-      <fmt:message key="div.vc" /></a></li>
+      <li><a href="vehiclesApiParams.jsp?a=${agencyId}"
+        title="Data for vehicles, including GPS info, for a route. Useful for showing location of vehicles on map.">
+          <fmt:message key="div.veh" /></a></li>
+      <li><a href="vehiclesDetailsApiParams.jsp?a=${agencyId}"
+        title="Detailed data for vehicles, including GPS info, for a route. Contains additional data such as schedule adherence and assignment information.">
+          <fmt:message key="div.vd" /></a></li>
+      <li><a href="vehicleConfigsApiParams.jsp?a=${agencyId}"
+        title="Configuration data for vehicles. A way of getting list of vehicles configured for agency.">
+          <fmt:message key="div.vc" /></a></li>
 
-  <li><a href="predsByRouteStopApiParams.jsp?a=${agencyId}"
-    title="Predictions for specified route and stop.">
-      <fmt:message key="div.pbrs" /></a></li>
-  <li><a href="predsByLocApiParams.jsp?a=${agencyId}"
-    title="Predictions for stops near specified latitude, longitude for the agency.">
-      <fmt:message key="div.pbl" /></a></li>
-  <li><a href="tripApiParams.jsp?a=${agencyId}"
-    title="Data for a single trip. Includes trip pattern and schedule info.">
-      <fmt:message key="div.dtrip" /></a></li>
-  <li><a href="tripWithTravelTimesApiParams.jsp?a=${agencyId}"
-    title="Data for a single trip. Includes trip pattern and schedule info as well as historic travel times used for generating predictions.">
-      <fmt:message key="div.twtt" /></a></li>
-  <li><a href="blocksTerseApiParams.jsp?a=${agencyId}"
-    title="Data for a block assignment. Shows each trip that makes up the block in a terse format, without trip pattern or schedule info.">
-      <fmt:message key="div.dblock" /></a></li>
-  <li><a href="blocksApiParams.jsp?a=${agencyId}"
-    title="Data for a block assignment. Shows each trip that makes up the block in a verbose format, including trip pattern and schedule info.">
-      <fmt:message key="div.bd" /></a></li>
+      <li><a href="predsByRouteStopApiParams.jsp?a=${agencyId}"
+        title="Predictions for specified route and stop.">
+          <fmt:message key="div.pbrs" /></a></li>
+      <li><a href="predsByLocApiParams.jsp?a=${agencyId}"
+        title="Predictions for stops near specified latitude, longitude for the agency.">
+          <fmt:message key="div.pbl" /></a></li>
+      <li><a href="tripApiParams.jsp?a=${agencyId}"
+        title="Data for a single trip. Includes trip pattern and schedule info.">
+          <fmt:message key="div.dtrip" /></a></li>
+      <li><a href="tripWithTravelTimesApiParams.jsp?a=${agencyId}"
+        title="Data for a single trip. Includes trip pattern and schedule info as well as historic travel times used for generating predictions.">
+          <fmt:message key="div.twtt" /></a></li>
+      <li><a href="blocksTerseApiParams.jsp?a=${agencyId}"
+        title="Data for a block assignment. Shows each trip that makes up the block in a terse format, without trip pattern or schedule info.">
+          <fmt:message key="div.dblock" /></a></li>
+      <li><a href="blocksApiParams.jsp?a=${agencyId}"
+        title="Data for a block assignment. Shows each trip that makes up the block in a verbose format, including trip pattern and schedule info.">
+          <fmt:message key="div.bd" /></a></li>
 
-  <li><a href="serviceIdsApiParams.jsp?a=${agencyId}"
-    title="Data for all service IDs configured for agency.">
-      <fmt:message key="div.si" /></a></li>
-  <li><a href="serviceIdsCurrentApiParams.jsp?a=${agencyId}"
-    title="Data for service IDs that are currently active for agency.">
-      <fmt:message key="div.sic" /></a></li>
+      <li><a href="serviceIdsApiParams.jsp?a=${agencyId}"
+        title="Data for all service IDs configured for agency.">
+          <fmt:message key="div.si" /></a></li>
+      <li><a href="serviceIdsCurrentApiParams.jsp?a=${agencyId}"
+        title="Data for service IDs that are currently active for agency.">
+          <fmt:message key="div.sic" /></a></li>
 
-  <li><a href="calendarsApiParams.jsp?a=${agencyId}"
-    title="Data for all calendars configured for agency.">
-      Calendars</a></li>
-  <li><a href="calendarsCurrentApiParams.jsp?a=${agencyId}"
-    title="Data for calendars that are currently active for agency.">
-      Calendars Current</a></li>
+      <li><a href="calendarsApiParams.jsp?a=${agencyId}"
+        title="Data for all calendars configured for agency.">
+          Calendars</a></li>
+      <li><a href="calendarsCurrentApiParams.jsp?a=${agencyId}"
+        title="Data for calendars that are currently active for agency.">
+          Calendars Current</a></li>
 
-  <li><a href="gtfsRealtimeTripUpdatesApiParams.jsp?a=${agencyId}"
-    title="GTFS-realtime Trip Updates includes prediction data for entire agency">
-      <fmt:message key="div.grtu" /></a></li>
-  <li><a href="gtfsRealtimeVehiclePositionsApiParams.jsp?a=${agencyId}"
-    title="GTFS-realtime Vehicle Positions for entire agency">
-      <fmt:message key="div.grvp" /></a></li>
+      <li><a href="gtfsRealtimeTripUpdatesApiParams.jsp?a=${agencyId}"
+        title="GTFS-realtime Trip Updates includes prediction data for entire agency">
+          <fmt:message key="div.grtu" /></a></li>
+      <li><a href="gtfsRealtimeVehiclePositionsApiParams.jsp?a=${agencyId}"
+        title="GTFS-realtime Vehicle Positions for entire agency">
+          <fmt:message key="div.grvp" /></a></li>
 
-  <li><a href="siriVehicleMonitoringApiParams.jsp?a=${agencyId}"
-    title="SIRI Vehicle Monitoring for specified route or entire agency">
-      <fmt:message key="div.svm" /></a></li>
-  <li><a href="siriStopMonitoringApiParams.jsp?a=${agencyId}"
-    title="SIRI Stop Monitoring for specified route and stop">
-      <fmt:message key="div.ssm" /></a></li>
+      <li><a href="siriVehicleMonitoringApiParams.jsp?a=${agencyId}"
+        title="SIRI Vehicle Monitoring for specified route or entire agency">
+          <fmt:message key="div.svm" /></a></li>
+      <li><a href="siriStopMonitoringApiParams.jsp?a=${agencyId}"
+        title="SIRI Stop Monitoring for specified route and stop">
+          <fmt:message key="div.ssm" /></a></li>
 
-  <li><a href="horizStopsScheduleApiParams.jsp?a=${agencyId}"
-    title="Schedule for route. For displaying schedule with stops listed in horizontal direction">
-      <fmt:message key="div.sfrsh" /></a></li>
-  <li><a href="vertStopsScheduleApiParams.jsp?a=${agencyId}"
-    title="Schedule for route. For displaying schedule with stops listed in vertical direction">
-      Schedule for Route, stops vertical</a></li>
-  <li><a href="resetVehicleApiParams.jsp?a=${agencyId}"
-    title="Reset specific vehicle">
-      <fmt:message key="div.sfrsv" /></a></li>
-</ul>
+      <li><a href="horizStopsScheduleApiParams.jsp?a=${agencyId}"
+        title="Schedule for route. For displaying schedule with stops listed in horizontal direction">
+          <fmt:message key="div.sfrsh" /></a></li>
+      <li><a href="vertStopsScheduleApiParams.jsp?a=${agencyId}"
+        title="Schedule for route. For displaying schedule with stops listed in vertical direction">
+          Schedule for Route, stops vertical</a></li>
+      <li><a href="resetVehicleApiParams.jsp?a=${agencyId}"
+        title="Reset specific vehicle">
+          <fmt:message key="div.sfrsv" /></a></li>
+    </ul>
 
-<div id="subtitle">Not Agency Specific</div>
-<ul class="choicesList">
-  <li><a href="agenciesApiParams.jsp"
-    title="List of all agencies available through the API">
-      <fmt:message key="div.agencies" /></a></li>
-  <li><a href="predsByLocForAllAgenciesApiParams.jsp?a=${agencyId}"
-    title="Predictions for stops near specified latitude, longitude. Will return predictions for all agencies that have nearby stops.">
-      <fmt:message key="div.pbl" /></a></li>
-
-</ul>
-</div>
+    <div id="subtitle">Not Agency Specific</div>
+    <ul class="list-disc list-outside pl-4">
+      <li><a href="agenciesApiParams.jsp"
+        title="List of all agencies available through the API">
+          <fmt:message key="div.agencies" /></a></li>
+      <li><a href="predsByLocForAllAgenciesApiParams.jsp?a=${agencyId}"
+        title="Predictions for stops near specified latitude, longitude. Will return predictions for all agencies that have nearby stops.">
+          <fmt:message key="div.pbl" /></a></li>
+    </ul>
   </jsp:body>
 </t:layout>

--- a/transitclockWebapp/src/main/webapp/reports/apiCalls/vertStopsScheduleApiParams.jsp
+++ b/transitclockWebapp/src/main/webapp/reports/apiCalls/vertStopsScheduleApiParams.jsp
@@ -1,37 +1,37 @@
 <t:layout>
-  <jsp:attribute name="title"><fmt:message key="div.SpecifyParameters" /></jsp:attribute>
+  <jsp:attribute name="title">
+    <fmt:message key="div.SpecifyParameters" />
+  </jsp:attribute>
   <jsp:attribute name="head">
     <!-- Load in Select2 files so can create fancy route selector -->
     <link href="//cdnjs.cloudflare.com/ajax/libs/select2/4.0.0/css/select2.min.css" rel="stylesheet" />
     <script src="//cdnjs.cloudflare.com/ajax/libs/select2/4.0.0/js/select2.min.js"></script>
 
-    <link href="../params/reportParams.css" rel="stylesheet"/>
+    <link href="../params/reportParams.css" rel="stylesheet" />
 
     <script>
       function execute() {
         var selectedRouteId = $("#route").val();
         var format = $('input:radio[name=format]:checked').val();
-    	  var url = apiUrlPrefix + "/command/scheduleVertStops?r=" + selectedRouteId + "&format=" + format;
+        var url = apiUrlPrefix + "/command/scheduleVertStops?r=" + selectedRouteId + "&format=" + format;
 
-     	  // Actually do the API call
-     	  location.href = url;
+        // Actually do the API call
+        location.href = url;
       }
     </script>
   </jsp:attribute>
   <jsp:body>
-<div id="title">
-   <fmt:message key="div.spfsvsa" />
-</div>
+    <div id="title">
+      <fmt:message key="div.spfsvsa" />
+    </div>
 
-<div id="mainDiv">
-   <%-- Create route selector --%>
-   <jsp:include page="../params/routeSingle.jsp" />
+    <%-- Create route selector --%>
+    <jsp:include page="../params/routeSingle.jsp" />
 
-   <%-- Create json/xml format radio buttons --%>
-   <jsp:include page="../params/jsonXmlFormat.jsp" />
+    <%-- Create json/xml format radio buttons --%>
+    <jsp:include page="../params/jsonXmlFormat.jsp" />
 
-   <%-- Create submit button --%>
-   <jsp:include page="../params/submitApiCall.jsp" />
-</div>
+    <%-- Create submit button --%>
+    <jsp:include page="../params/submitApiCall.jsp" />
   </jsp:body>
 </t:layout>

--- a/transitclockWebapp/src/main/webapp/status/activeBlocks.jsp
+++ b/transitclockWebapp/src/main/webapp/status/activeBlocks.jsp
@@ -50,45 +50,8 @@ pageContext.setAttribute("currentYear",      java.time.Year.now().getValue());
 
   <%-- Bleeds out of the layout's p-8 padding via -mx-8 so the bar spans
        the full main width and stays flush at the scroll-container edge. --%>
-  <div data-active-blocks-target="summary"
-       class="sticky top-0 z-10 -mx-8 mb-5 px-8 pt-3 pb-3 bg-canvas/90 backdrop-blur">
-    <div class="flex items-stretch bg-white border border-gray-200 rounded-lg overflow-hidden shadow-[0_1px_2px_rgba(0,0,0,0.03)]">
-      <div class="flex-1 min-w-0 px-4 py-3 border-r border-gray-200">
-        <div class="text-[11px] font-semibold uppercase tracking-wider text-gray-500"><fmt:message key="div.blocks"/></div>
-        <div class="flex items-baseline gap-1.5 mt-0.5">
-          <span data-field="total-blocks" class="text-[22px] font-bold tabular-nums text-gray-900">—</span>
-          <span class="text-xs text-gray-500 font-medium">total</span>
-        </div>
-      </div>
-      <div class="flex-1 min-w-0 px-4 py-3 border-r border-gray-200">
-        <div class="text-[11px] font-semibold uppercase tracking-wider text-gray-500"><fmt:message key="div.assigned"/></div>
-        <div class="flex items-baseline gap-1.5 mt-0.5">
-          <span data-field="percent-assigned" class="text-[22px] font-bold tabular-nums text-brand-accent">—</span>
-          <span data-field="assigned-detail" class="text-xs text-gray-500 font-medium tabular-nums"></span>
-        </div>
-      </div>
-      <div class="flex-1 min-w-0 px-4 py-3 border-r border-gray-200">
-        <div class="text-[11px] font-semibold uppercase tracking-wider text-gray-500"><fmt:message key="div.contime"/></div>
-        <div class="flex items-baseline gap-1.5 mt-0.5">
-          <span data-field="percent-on-time" class="text-[22px] font-bold tabular-nums text-status-on-time-ink">—</span>
-          <span data-field="on-time-count" class="text-xs text-gray-500 font-medium tabular-nums"></span>
-        </div>
-      </div>
-      <div class="flex-1 min-w-0 px-4 py-3 border-r border-gray-200" title="Vehicle is more than ${scheduleLateMin} min late">
-        <div class="text-[11px] font-semibold uppercase tracking-wider text-gray-500"><fmt:message key="div.clate"/></div>
-        <div class="flex items-baseline gap-1.5 mt-0.5">
-          <span data-field="percent-late" class="text-[22px] font-bold tabular-nums text-status-late">—</span>
-          <span data-field="late-count" class="text-xs text-gray-500 font-medium tabular-nums"></span>
-        </div>
-      </div>
-      <div class="flex-1 min-w-0 px-4 py-3" title="Vehicle is more than ${scheduleEarlyMin} min early">
-        <div class="text-[11px] font-semibold uppercase tracking-wider text-gray-500"><fmt:message key="div.cearly"/></div>
-        <div class="flex items-baseline gap-1.5 mt-0.5">
-          <span data-field="percent-early" class="text-[22px] font-bold tabular-nums text-status-early">—</span>
-          <span data-field="early-count" class="text-xs text-gray-500 font-medium tabular-nums"></span>
-        </div>
-      </div>
-    </div>
+  <div class="sticky top-0 z-10 -mx-8 mb-5 px-8 pt-3 pb-3 bg-canvas/90 backdrop-blur">
+    <t:activeBlocksSummary/>
   </div>
 
   <div data-controller="accordion"

--- a/transitclockWebapp/src/main/webapp/status/serverStatus.jsp
+++ b/transitclockWebapp/src/main/webapp/status/serverStatus.jsp
@@ -53,43 +53,6 @@ try {
   </div>
 </div>
 
-<c:choose>
-  <c:when test="${not empty rmiError}">
-    <div class="rounded-lg border border-red-200 bg-red-50 p-4">
-      <h2 class="text-sm font-semibold text-red-900"><fmt:message key="div.coreUnreachable" /></h2>
-      <p class="mt-1 text-sm text-red-800 font-mono break-all"><c:out value="${rmiError}"/></p>
-    </div>
-  </c:when>
-  <c:otherwise>
-    <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-      <c:forEach var="monitorResult" items="${monitorResults}">
-        <c:if test="${not empty monitorResult.message}">
-          <article class="bg-white border border-gray-200 rounded-lg p-4">
-            <h2 class="text-xs font-semibold uppercase tracking-wider text-gray-500">
-              <c:out value="${monitorResult.type}"/>
-            </h2>
-            <c:choose>
-              <c:when test="${not empty monitorResult.stats}">
-                <dl class="mt-3 grid grid-cols-2 gap-x-4 gap-y-1.5 text-sm">
-                  <c:forEach var="stat" items="${monitorResult.stats}">
-                    <div class="flex items-baseline gap-1.5 col-span-2 sm:col-span-1">
-                      <dt class="text-gray-500"><c:out value="${stat.key}"/>:</dt>
-                      <dd class="font-mono text-gray-900"><c:out value="${stat.value}"/></dd>
-                    </div>
-                  </c:forEach>
-                </dl>
-              </c:when>
-              <c:otherwise>
-                <p class="mt-2 text-sm text-gray-900 leading-relaxed tabular-nums">
-                  <c:out value="${monitorResult.message}"/>
-                </p>
-              </c:otherwise>
-            </c:choose>
-          </article>
-        </c:if>
-      </c:forEach>
-    </div>
-  </c:otherwise>
-</c:choose>
+<t:serverStatusGrid monitorResults="${monitorResults}" error="${rmiError}"/>
   </jsp:body>
 </t:layout>


### PR DESCRIPTION
## Summary

- Adds a new Dashboard page (`/dashboard/index.jsp`) that combines the Active Blocks summary, Server Status monitor grid, and the five largest DB tables (horizontal-bar chart + table) onto one overview page. Wired as the first link under each agency in the sidebar.
- Extracts the active-blocks summary stat-strip and the server-status monitor grid into shared `<t:>` tags (`activeBlocksSummary.tag`, `serverStatusGrid.tag`) so the original `/status/activeBlocks.jsp` and `/status/serverStatus.jsp` pages render the same markup as the dashboard.
- Adds `DbDiskSpaceQuery.getTopTables(agencyId, limit)` returning a typed `List<TableSize>`. The dashboard renders bars/table directly from these rows; no new charting dependency.
- Makes the `active-blocks` Stimulus controller short-circuit route fetching when the accordion/route-template targets are absent so the dashboard can mount the controller for the summary strip alone.

## Test plan

- [x] `mvn -pl transitclockWebapp -am package -DskipTests` builds clean.
- [x] Existing webapp tests pass (`mvn -pl transitclockWebapp test`) — the `DbDiskSpaceQueryTest` and JSP audit tests are green. (One pre-existing `DbDiskSpaceResourceTest` failure on `NoClassDefFound com/fasterxml/jackson/databind/ObjectMapper` is unrelated to this PR; it was introduced in `b972cee3` against the webapp's deliberately-Jackson-excluded runtime — flagged below.)
- [x] `/dashboard/index.jsp?a=1` renders the three sections with live data (verified in browser via Playwright; zero console errors).
- [x] `/status/activeBlocks.jsp?a=1` regression check — full page including the route accordion still renders and the Stimulus controller fetches both summary and per-route data with no console errors.
- [x] `/status/serverStatus.jsp?a=1` regression check — monitor grid renders identically.
- [x] `/status/dbDiskSpace.jsp?a=1` regression check — Google Charts chart and tables still render.
- [x] Sidebar shows Dashboard as the first entry under the agency name, with the active-pill highlight when on the dashboard.

## Review notes (non-blocking, for reviewer judgment)

- **Heading-level skip on `/status/serverStatus.jsp`.** The shared `serverStatusGrid.tag` emits `<h3>` for the alert and per-monitor headings. On the dashboard the page's own `<h1>` and section `<h2>` make this correct, but on `serverStatus.jsp` (which has only an `<h1>`) it skips an h2. JSP EL can't expand inside element names, so making this a tag attribute would mean a `<c:choose>` per heading. Leaving as-is for now; happy to add the choose if reviewer prefers strict heading hierarchy.
- **No new test for `getTopTables`.** The existing `DbDiskSpaceQueryTest` covers `getTotalsJson` / `getDetailsJson`. A unit test pinning the LIMIT clamp at the bounds and the `addRow` mapping into `TableSize` would catch future drift; leaving as a follow-up.
- **`TableSize.prettySize` field couples the API surface to Postgres `pg_size_pretty` formatting.** Fine for the current single consumer but worth revisiting if a second consumer ever wants different formatting/locale; a `Bytes.humanize(long)` helper plus dropping the field would be the cleanup.
- **Pre-existing `GenericQuery` static-Connection.** `org.transitclock.db.GenericQuery` keeps a `static Connection` reassigned by every constructor and never closed. The dashboard adds another concurrent caller (`getTopTables` alongside the existing `getTotalsJson`), making the latent thread-safety/leak concern a little more reachable. Out of scope for this PR.
- **Pre-existing test failure unrelated to this branch.** `DbDiskSpaceResourceTest.happyPath_wrapsBothJsonsInEnvelope` fails with `NoClassDefFound com/fasterxml/jackson/databind/ObjectMapper`. The webapp `pom.xml` deliberately excludes `jersey-media-json-jackson` (per its own comment) to keep Hibernate's Jackson chain at 2.8.9. Worth a separate fix to either provide Jackson at test scope only or remove the `ObjectMapper.readTree` line.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a new Dashboard page featuring server status monitoring, top database table disk usage metrics, and active block statistics.

* **Localization**
  * Added Polish language support for Dashboard labels.

* **Refactor**
  * Updated styling and layout in API reports and removed legacy CSS rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->