### PR TITLE
Adapt API calls page to mimic the 3-column reports layout

### DIFF
--- a/transitclockWebapp/src/main/webapp/WEB-INF/tags/apiCallLayout.tag
+++ b/transitclockWebapp/src/main/webapp/WEB-INF/tags/apiCallLayout.tag
@@ -1,0 +1,14 @@
+<%@ tag pageEncoding="UTF-8" %>
+<%@ taglib prefix="t" tagdir="/WEB-INF/tags" %>
+<%@ attribute name="title" required="false" %>
+<%@ attribute name="head"  fragment="true" required="false" %>
+<%-- API call sub-pages use this so the API Calls sidebar stays visible
+     when drilling into a specific call, mirroring how reports/* pages
+     keep the Reports sidebar visible. The p-8 wrapper restores the
+     padding that t:layout gives by default and that t:splitLayout
+     (which is bare) does not. --%>
+<t:splitLayout title="${title}">
+  <jsp:attribute name="head"><jsp:invoke fragment="head"/></jsp:attribute>
+  <jsp:attribute name="sidebar"><t:apiCallsSidebar/></jsp:attribute>
+  <jsp:body><div class="p-8"><jsp:doBody/></div></jsp:body>
+</t:splitLayout>

--- a/transitclockWebapp/src/main/webapp/WEB-INF/tags/apiCallsSidebar.tag
+++ b/transitclockWebapp/src/main/webapp/WEB-INF/tags/apiCallsSidebar.tag
@@ -1,0 +1,84 @@
+<%@ tag pageEncoding="UTF-8" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
+<%@ taglib prefix="t"   tagdir="/WEB-INF/tags" %>
+<t:secondarySidebar title="API Calls">
+  <div>
+    <h3 class="px-2 mb-1 text-xs font-semibold text-gray-500 uppercase tracking-wider">Routes</h3>
+    <ul class="space-y-0.5">
+      <t:secondarySidebarLink path="/reports/apiCalls/routeApiParams.jsp"        title="Summary data for all routes, listed in order. Useful for creating a UI selector for routes."><fmt:message key="div.rou"/></t:secondarySidebarLink>
+      <t:secondarySidebarLink path="/reports/apiCalls/routeDetailsApiParams.jsp" title="Detailed data for selected routes. Includes stop and path information needed to show route on map."><fmt:message key="div.roude"/></t:secondarySidebarLink>
+    </ul>
+  </div>
+  <div>
+    <h3 class="px-2 mb-1 text-xs font-semibold text-gray-500 uppercase tracking-wider">Vehicles</h3>
+    <ul class="space-y-0.5">
+      <t:secondarySidebarLink path="/reports/apiCalls/vehiclesApiParams.jsp"        title="Data for vehicles, including GPS info, for a route. Useful for showing location of vehicles on map."><fmt:message key="div.veh"/></t:secondarySidebarLink>
+      <t:secondarySidebarLink path="/reports/apiCalls/vehiclesDetailsApiParams.jsp" title="Detailed data for vehicles, including GPS info, for a route. Contains additional data such as schedule adherence and assignment information."><fmt:message key="div.vd"/></t:secondarySidebarLink>
+      <t:secondarySidebarLink path="/reports/apiCalls/vehicleConfigsApiParams.jsp"  title="Configuration data for vehicles. A way of getting list of vehicles configured for agency."><fmt:message key="div.vc"/></t:secondarySidebarLink>
+    </ul>
+  </div>
+  <div>
+    <h3 class="px-2 mb-1 text-xs font-semibold text-gray-500 uppercase tracking-wider">Predictions</h3>
+    <ul class="space-y-0.5">
+      <t:secondarySidebarLink path="/reports/apiCalls/predsByRouteStopApiParams.jsp" title="Predictions for specified route and stop."><fmt:message key="div.pbrs"/></t:secondarySidebarLink>
+      <t:secondarySidebarLink path="/reports/apiCalls/predsByLocApiParams.jsp"      title="Predictions for stops near specified latitude, longitude for the agency."><fmt:message key="div.pbl"/></t:secondarySidebarLink>
+    </ul>
+  </div>
+  <div>
+    <h3 class="px-2 mb-1 text-xs font-semibold text-gray-500 uppercase tracking-wider">Trips &amp; Blocks</h3>
+    <ul class="space-y-0.5">
+      <t:secondarySidebarLink path="/reports/apiCalls/tripApiParams.jsp"                title="Data for a single trip. Includes trip pattern and schedule info."><fmt:message key="div.dtrip"/></t:secondarySidebarLink>
+      <t:secondarySidebarLink path="/reports/apiCalls/tripWithTravelTimesApiParams.jsp" title="Data for a single trip. Includes trip pattern and schedule info as well as historic travel times used for generating predictions."><fmt:message key="div.twtt"/></t:secondarySidebarLink>
+      <t:secondarySidebarLink path="/reports/apiCalls/blocksTerseApiParams.jsp"         title="Data for a block assignment. Shows each trip that makes up the block in a terse format, without trip pattern or schedule info."><fmt:message key="div.dblock"/></t:secondarySidebarLink>
+      <t:secondarySidebarLink path="/reports/apiCalls/blocksApiParams.jsp"              title="Data for a block assignment. Shows each trip that makes up the block in a verbose format, including trip pattern and schedule info."><fmt:message key="div.bd"/></t:secondarySidebarLink>
+    </ul>
+  </div>
+  <div>
+    <h3 class="px-2 mb-1 text-xs font-semibold text-gray-500 uppercase tracking-wider">Service IDs</h3>
+    <ul class="space-y-0.5">
+      <t:secondarySidebarLink path="/reports/apiCalls/serviceIdsApiParams.jsp"        title="Data for all service IDs configured for agency."><fmt:message key="div.si"/></t:secondarySidebarLink>
+      <t:secondarySidebarLink path="/reports/apiCalls/serviceIdsCurrentApiParams.jsp" title="Data for service IDs that are currently active for agency."><fmt:message key="div.sic"/></t:secondarySidebarLink>
+    </ul>
+  </div>
+  <div>
+    <h3 class="px-2 mb-1 text-xs font-semibold text-gray-500 uppercase tracking-wider">Calendars</h3>
+    <ul class="space-y-0.5">
+      <t:secondarySidebarLink path="/reports/apiCalls/calendarsApiParams.jsp"        title="Data for all calendars configured for agency.">Calendars</t:secondarySidebarLink>
+      <t:secondarySidebarLink path="/reports/apiCalls/calendarsCurrentApiParams.jsp" title="Data for calendars that are currently active for agency.">Calendars Current</t:secondarySidebarLink>
+    </ul>
+  </div>
+  <div>
+    <h3 class="px-2 mb-1 text-xs font-semibold text-gray-500 uppercase tracking-wider">GTFS-realtime</h3>
+    <ul class="space-y-0.5">
+      <t:secondarySidebarLink path="/reports/apiCalls/gtfsRealtimeTripUpdatesApiParams.jsp"      title="GTFS-realtime Trip Updates includes prediction data for entire agency"><fmt:message key="div.grtu"/></t:secondarySidebarLink>
+      <t:secondarySidebarLink path="/reports/apiCalls/gtfsRealtimeVehiclePositionsApiParams.jsp" title="GTFS-realtime Vehicle Positions for entire agency"><fmt:message key="div.grvp"/></t:secondarySidebarLink>
+    </ul>
+  </div>
+  <div>
+    <h3 class="px-2 mb-1 text-xs font-semibold text-gray-500 uppercase tracking-wider">SIRI</h3>
+    <ul class="space-y-0.5">
+      <t:secondarySidebarLink path="/reports/apiCalls/siriVehicleMonitoringApiParams.jsp" title="SIRI Vehicle Monitoring for specified route or entire agency"><fmt:message key="div.svm"/></t:secondarySidebarLink>
+      <t:secondarySidebarLink path="/reports/apiCalls/siriStopMonitoringApiParams.jsp"    title="SIRI Stop Monitoring for specified route and stop"><fmt:message key="div.ssm"/></t:secondarySidebarLink>
+    </ul>
+  </div>
+  <div>
+    <h3 class="px-2 mb-1 text-xs font-semibold text-gray-500 uppercase tracking-wider">Schedules</h3>
+    <ul class="space-y-0.5">
+      <t:secondarySidebarLink path="/reports/apiCalls/horizStopsScheduleApiParams.jsp" title="Schedule for route. For displaying schedule with stops listed in horizontal direction"><fmt:message key="div.sfrsh"/></t:secondarySidebarLink>
+      <t:secondarySidebarLink path="/reports/apiCalls/vertStopsScheduleApiParams.jsp"  title="Schedule for route. For displaying schedule with stops listed in vertical direction"><fmt:message key="div.sfrsv"/></t:secondarySidebarLink>
+    </ul>
+  </div>
+  <div>
+    <h3 class="px-2 mb-1 text-xs font-semibold text-gray-500 uppercase tracking-wider">Commands</h3>
+    <ul class="space-y-0.5">
+      <t:secondarySidebarLink path="/reports/apiCalls/resetVehicleApiParams.jsp" title="Reset specific vehicle"><fmt:message key="div.rv"/></t:secondarySidebarLink>
+    </ul>
+  </div>
+  <div>
+    <h3 class="px-2 mb-1 text-xs font-semibold text-gray-500 uppercase tracking-wider"><fmt:message key="div.nas"/></h3>
+    <ul class="space-y-0.5">
+      <t:secondarySidebarLink path="/reports/apiCalls/agenciesApiParams.jsp"              title="List of all agencies available through the API" omitAgency="true"><fmt:message key="div.agencies"/></t:secondarySidebarLink>
+      <t:secondarySidebarLink path="/reports/apiCalls/predsByLocForAllAgenciesApiParams.jsp" title="Predictions for stops near specified latitude, longitude. Will return predictions for all agencies that have nearby stops."><fmt:message key="div.pbl"/></t:secondarySidebarLink>
+    </ul>
+  </div>
+</t:secondarySidebar>

--- a/transitclockWebapp/src/main/webapp/WEB-INF/tags/reportsLayout.tag
+++ b/transitclockWebapp/src/main/webapp/WEB-INF/tags/reportsLayout.tag
@@ -1,21 +1,9 @@
 <%@ tag pageEncoding="UTF-8" %>
-<%@ taglib prefix="c"   uri="jakarta.tags.core" %>
-<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
-<%@ taglib prefix="t"   tagdir="/WEB-INF/tags" %>
+<%@ taglib prefix="t" tagdir="/WEB-INF/tags" %>
 <%@ attribute name="title" required="false" %>
 <%@ attribute name="head"  fragment="true" required="false" %>
-<%-- bare="true" so the inner sidebar+content flex container can fill
-     the main pane itself; the default p-8 wrapper would double-pad. --%>
-<t:layout title="${title}" bare="true">
-  <jsp:attribute name="head">
-    <jsp:invoke fragment="head"/>
-  </jsp:attribute>
-  <jsp:body>
-    <div class="flex h-full">
-      <t:reportsSidebar/>
-      <div class="flex-1 overflow-y-auto">
-        <jsp:doBody/>
-      </div>
-    </div>
-  </jsp:body>
-</t:layout>
+<t:splitLayout title="${title}">
+  <jsp:attribute name="head"><jsp:invoke fragment="head"/></jsp:attribute>
+  <jsp:attribute name="sidebar"><t:reportsSidebar/></jsp:attribute>
+  <jsp:body><jsp:doBody/></jsp:body>
+</t:splitLayout>

--- a/transitclockWebapp/src/main/webapp/WEB-INF/tags/reportsSidebar.tag
+++ b/transitclockWebapp/src/main/webapp/WEB-INF/tags/reportsSidebar.tag
@@ -1,61 +1,51 @@
 <%@ tag pageEncoding="UTF-8" %>
-<%@ taglib prefix="c"   uri="jakarta.tags.core" %>
 <%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
-<c:set var="ctx"  value="${pageContext.request.contextPath}"/>
-<c:set var="qs"   value="?a=${param.a}"/>
-<c:set var="path" value="${pageContext.request.servletPath}"/>
-<c:set var="active"   value="bg-indigo-50 text-indigo-700 font-medium"/>
-<c:set var="inactive" value="text-gray-700 hover:bg-gray-100 hover:text-gray-900"/>
-<aside class="hidden md:flex md:flex-col w-64 lg:w-72 shrink-0 border-r border-gray-200 bg-gray-50">
-  <div class="px-5 py-4 border-b border-gray-200">
-    <h2 class="text-base font-semibold text-gray-900">Reports</h2>
+<%@ taglib prefix="t"   tagdir="/WEB-INF/tags" %>
+<t:secondarySidebar title="Reports">
+  <div>
+    <h3 class="px-2 mb-1 text-xs font-semibold text-gray-500 uppercase tracking-wider"><fmt:message key="div.pa"/></h3>
+    <ul class="space-y-0.5">
+      <t:secondarySidebarLink path="/reports/predAccuracyRangeParams.jsp"     title="Shows percentage of predictions that were accurate to within the specified limits."><fmt:message key="div.prediction"/></t:secondarySidebarLink>
+      <t:secondarySidebarLink path="/reports/predAccuracyIntervalsParams.jsp" title="Shows average prediction accuracy for each prediction length, with upper and lower bounds."><fmt:message key="div.PredictionAccuracyIntervalChart"/></t:secondarySidebarLink>
+      <t:secondarySidebarLink path="/reports/predAccuracyScatterParams.jsp"   title="Shows each individual datapoint for prediction accuracy. Useful for finding specific issues with predictions."><fmt:message key="div.predictionscatter"/></t:secondarySidebarLink>
+      <t:secondarySidebarLink path="/reports/predAccuracyCsvParams.jsp"       title="Download prediction accuracy data in CSV format."><fmt:message key="div.csv"/></t:secondarySidebarLink>
+      <t:secondarySidebarLink path="/reports/routePerformanceTable.jsp"       title="Shows route performance: number of on-time predictions over total predictions for a given route."><fmt:message key="div.RoutePerformanceTable"/></t:secondarySidebarLink>
+    </ul>
   </div>
-  <nav class="flex-1 overflow-y-auto px-3 py-4 space-y-6">
-    <div>
-      <h3 class="px-2 mb-1 text-xs font-semibold text-gray-500 uppercase tracking-wider"><fmt:message key="div.pa"/></h3>
-      <ul class="space-y-0.5">
-        <li><a class="block px-2 py-1.5 text-sm rounded ${path == '/reports/predAccuracyRangeParams.jsp'     ? active : inactive}" href="${ctx}/reports/predAccuracyRangeParams.jsp${qs}"     title="Shows percentage of predictions that were accurate to within the specified limits."><fmt:message key="div.prediction"/></a></li>
-        <li><a class="block px-2 py-1.5 text-sm rounded ${path == '/reports/predAccuracyIntervalsParams.jsp' ? active : inactive}" href="${ctx}/reports/predAccuracyIntervalsParams.jsp${qs}" title="Shows average prediction accuracy for each prediction length, with upper and lower bounds."><fmt:message key="div.PredictionAccuracyIntervalChart"/></a></li>
-        <li><a class="block px-2 py-1.5 text-sm rounded ${path == '/reports/predAccuracyScatterParams.jsp'   ? active : inactive}" href="${ctx}/reports/predAccuracyScatterParams.jsp${qs}"   title="Shows each individual datapoint for prediction accuracy. Useful for finding specific issues with predictions."><fmt:message key="div.predictionscatter"/></a></li>
-        <li><a class="block px-2 py-1.5 text-sm rounded ${path == '/reports/predAccuracyCsvParams.jsp'       ? active : inactive}" href="${ctx}/reports/predAccuracyCsvParams.jsp${qs}"       title="Download prediction accuracy data in CSV format."><fmt:message key="div.csv"/></a></li>
-        <li><a class="block px-2 py-1.5 text-sm rounded ${path == '/reports/routePerformanceTable.jsp'      ? active : inactive}" href="${ctx}/reports/routePerformanceTable.jsp${qs}"      title="Shows route performance: number of on-time predictions over total predictions for a given route."><fmt:message key="div.RoutePerformanceTable"/></a></li>
-      </ul>
-    </div>
-    <div>
-      <h3 class="px-2 mb-1 text-xs font-semibold text-gray-500 uppercase tracking-wider"><fmt:message key="div.ar"/></h3>
-      <ul class="space-y-0.5">
-        <li><a class="block px-2 py-1.5 text-sm rounded ${path == '/reports/avlMap.jsp'        ? active : inactive}" href="${ctx}/reports/avlMap.jsp${qs}"        title="Display historic AVL data for a vehicle on a map."><fmt:message key="div.AVLDataInMap"/></a></li>
-        <li><a class="block px-2 py-1.5 text-sm rounded ${path == '/reports/avlMapParams.jsp'  ? active : inactive}" href="${ctx}/reports/avlMapParams.jsp${qs}"  title="Display historic AVL data for a vehicle on a map (with parameters)."><fmt:message key="div.AVLDataInMapParametersPage"/></a></li>
-        <li><a class="block px-2 py-1.5 text-sm rounded ${path == '/reports/lastAvlReport.jsp' ? active : inactive}" href="${ctx}/reports/lastAvlReport.jsp${qs}" title="Show the last time each vehicle reported its GPS position over the last 24 hours."><fmt:message key="div.lastgpsreports"/></a></li>
-      </ul>
-    </div>
-    <div>
-      <h3 class="px-2 mb-1 text-xs font-semibold text-gray-500 uppercase tracking-wider"><fmt:message key="div.EventReports"/></h3>
-      <ul class="space-y-0.5">
-        <li><a class="block px-2 py-1.5 text-sm rounded ${path == '/reports/vehicleEventParams.jsp' ? active : inactive}" href="${ctx}/reports/vehicleEventParams.jsp${qs}" title="View all events for a vehicle."><fmt:message key="div.EventForVehicle"/></a></li>
-      </ul>
-    </div>
-    <div>
-      <h3 class="px-2 mb-1 text-xs font-semibold text-gray-500 uppercase tracking-wider"><fmt:message key="div.sar"/></h3>
-      <ul class="space-y-0.5">
-        <li><a class="block px-2 py-1.5 text-sm rounded ${path == '/reports/schAdhByRouteParams.jsp' ? active : inactive}" href="${ctx}/reports/schAdhByRouteParams.jsp${qs}" title="Schedule adherence by route, in a bar chart. Can compare multiple routes."><fmt:message key="div.scheduleroutr"/></a></li>
-        <li><a class="block px-2 py-1.5 text-sm rounded ${path == '/reports/schAdhByStopParams.jsp'  ? active : inactive}" href="${ctx}/reports/schAdhByStopParams.jsp${qs}"  title="Schedule adherence for each stop on a route, in a bar chart."><fmt:message key="div.schedulebystop"/></a></li>
-        <li><a class="block px-2 py-1.5 text-sm rounded ${path == '/reports/schAdhByTimeParams.jsp'  ? active : inactive}" href="${ctx}/reports/schAdhByTimeParams.jsp${qs}"  title="Schedule adherence for a route grouped by how early or late."><fmt:message key="div.earlylate"/></a></li>
-      </ul>
-    </div>
-    <div>
-      <h3 class="px-2 mb-1 text-xs font-semibold text-gray-500 uppercase tracking-wider"><fmt:message key="div.mr"/></h3>
-      <ul class="space-y-0.5">
-        <li><a class="block px-2 py-1.5 text-sm rounded ${path == '/reports/scheduleHorizStopsParams.jsp' ? active : inactive}" href="${ctx}/reports/scheduleHorizStopsParams.jsp${qs}" title="Display the schedule for a specified route in a table."><fmt:message key="div.schedulefor"/></a></li>
-        <li><a class="block px-2 py-1.5 text-sm rounded ${path == '/reports/scheduleVertStopsParams.jsp'  ? active : inactive}" href="${ctx}/reports/scheduleVertStopsParams.jsp${qs}"  title="Schedule for a route with stops listed vertically. Useful when there are few trips per day."><fmt:message key="div.sfrvss"/></a></li>
-      </ul>
-    </div>
-    <div>
-      <h3 class="px-2 mb-1 text-xs font-semibold text-gray-500 uppercase tracking-wider"><fmt:message key="div.sr"/></h3>
-      <ul class="space-y-0.5">
-        <li><a class="block px-2 py-1.5 text-sm rounded ${path == '/status/activeBlocks.jsp' ? active : inactive}" href="${ctx}/status/activeBlocks.jsp${qs}" title="How many block assignments are currently active and which have assigned vehicles."><fmt:message key="div.acbiveblock"/></a></li>
-        <li><a class="block px-2 py-1.5 text-sm rounded ${path == '/status/serverStatus.jsp' ? active : inactive}" href="${ctx}/status/serverStatus.jsp${qs}" title="How well the system is running, including the AVL feed."><fmt:message key="div.ss"/></a></li>
-      </ul>
-    </div>
-  </nav>
-</aside>
+  <div>
+    <h3 class="px-2 mb-1 text-xs font-semibold text-gray-500 uppercase tracking-wider"><fmt:message key="div.ar"/></h3>
+    <ul class="space-y-0.5">
+      <t:secondarySidebarLink path="/reports/avlMap.jsp"        title="Display historic AVL data for a vehicle on a map."><fmt:message key="div.AVLDataInMap"/></t:secondarySidebarLink>
+      <t:secondarySidebarLink path="/reports/avlMapParams.jsp"  title="Display historic AVL data for a vehicle on a map (with parameters)."><fmt:message key="div.AVLDataInMapParametersPage"/></t:secondarySidebarLink>
+      <t:secondarySidebarLink path="/reports/lastAvlReport.jsp" title="Show the last time each vehicle reported its GPS position over the last 24 hours."><fmt:message key="div.lastgpsreports"/></t:secondarySidebarLink>
+    </ul>
+  </div>
+  <div>
+    <h3 class="px-2 mb-1 text-xs font-semibold text-gray-500 uppercase tracking-wider"><fmt:message key="div.EventReports"/></h3>
+    <ul class="space-y-0.5">
+      <t:secondarySidebarLink path="/reports/vehicleEventParams.jsp" title="View all events for a vehicle."><fmt:message key="div.EventForVehicle"/></t:secondarySidebarLink>
+    </ul>
+  </div>
+  <div>
+    <h3 class="px-2 mb-1 text-xs font-semibold text-gray-500 uppercase tracking-wider"><fmt:message key="div.sar"/></h3>
+    <ul class="space-y-0.5">
+      <t:secondarySidebarLink path="/reports/schAdhByRouteParams.jsp" title="Schedule adherence by route, in a bar chart. Can compare multiple routes."><fmt:message key="div.scheduleroutr"/></t:secondarySidebarLink>
+      <t:secondarySidebarLink path="/reports/schAdhByStopParams.jsp"  title="Schedule adherence for each stop on a route, in a bar chart."><fmt:message key="div.schedulebystop"/></t:secondarySidebarLink>
+      <t:secondarySidebarLink path="/reports/schAdhByTimeParams.jsp"  title="Schedule adherence for a route grouped by how early or late."><fmt:message key="div.earlylate"/></t:secondarySidebarLink>
+    </ul>
+  </div>
+  <div>
+    <h3 class="px-2 mb-1 text-xs font-semibold text-gray-500 uppercase tracking-wider"><fmt:message key="div.mr"/></h3>
+    <ul class="space-y-0.5">
+      <t:secondarySidebarLink path="/reports/scheduleHorizStopsParams.jsp" title="Display the schedule for a specified route in a table."><fmt:message key="div.schedulefor"/></t:secondarySidebarLink>
+      <t:secondarySidebarLink path="/reports/scheduleVertStopsParams.jsp"  title="Schedule for a route with stops listed vertically. Useful when there are few trips per day."><fmt:message key="div.sfrvss"/></t:secondarySidebarLink>
+    </ul>
+  </div>
+  <div>
+    <h3 class="px-2 mb-1 text-xs font-semibold text-gray-500 uppercase tracking-wider"><fmt:message key="div.sr"/></h3>
+    <ul class="space-y-0.5">
+      <t:secondarySidebarLink path="/status/activeBlocks.jsp" title="How many block assignments are currently active and which have assigned vehicles."><fmt:message key="div.acbiveblock"/></t:secondarySidebarLink>
+      <t:secondarySidebarLink path="/status/serverStatus.jsp" title="How well the system is running, including the AVL feed."><fmt:message key="div.ss"/></t:secondarySidebarLink>
+    </ul>
+  </div>
+</t:secondarySidebar>

--- a/transitclockWebapp/src/main/webapp/WEB-INF/tags/secondarySidebar.tag
+++ b/transitclockWebapp/src/main/webapp/WEB-INF/tags/secondarySidebar.tag
@@ -7,7 +7,7 @@
   <div class="px-5 py-4 border-b border-gray-200">
     <h2 class="text-base font-semibold text-gray-900">${title}</h2>
   </div>
-  <nav class="flex-1 overflow-y-auto px-3 py-4 space-y-6">
+  <nav aria-label="${title}" class="flex-1 overflow-y-auto px-3 py-4 space-y-6">
     <jsp:doBody/>
   </nav>
 </aside>

--- a/transitclockWebapp/src/main/webapp/WEB-INF/tags/secondarySidebar.tag
+++ b/transitclockWebapp/src/main/webapp/WEB-INF/tags/secondarySidebar.tag
@@ -1,0 +1,13 @@
+<%@ tag pageEncoding="UTF-8" %>
+<%@ attribute name="title" required="true" %>
+<%-- Middle-column sidebar shell shared by reports and API calls index pages.
+     The body should contain section <div>s with their own headings/links;
+     this tag only owns the wrapper, title row, and scroll container. --%>
+<aside class="hidden md:flex md:flex-col w-64 lg:w-72 shrink-0 border-r border-gray-200 bg-gray-50">
+  <div class="px-5 py-4 border-b border-gray-200">
+    <h2 class="text-base font-semibold text-gray-900">${title}</h2>
+  </div>
+  <nav class="flex-1 overflow-y-auto px-3 py-4 space-y-6">
+    <jsp:doBody/>
+  </nav>
+</aside>

--- a/transitclockWebapp/src/main/webapp/WEB-INF/tags/secondarySidebarLink.tag
+++ b/transitclockWebapp/src/main/webapp/WEB-INF/tags/secondarySidebarLink.tag
@@ -1,0 +1,13 @@
+<%@ tag pageEncoding="UTF-8" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
+<%@ attribute name="path"       required="true"  %>
+<%@ attribute name="title"      required="false" %>
+<%@ attribute name="omitAgency" required="false" type="java.lang.Boolean" %>
+<%-- Active-state link for use inside <t:secondarySidebar>. `path` is matched
+     against the current servletPath to highlight the row, and is also the
+     href. `omitAgency="true"` drops the ?a=... query string (e.g. for
+     /reports/apiCalls/agenciesApiParams.jsp, which lists all agencies and
+     therefore takes no agency param). The body provides the link label. --%>
+<c:set var="curPath" value="${pageContext.request.servletPath}"/>
+<c:set var="ctx"     value="${pageContext.request.contextPath}"/>
+<li><a class="block px-2 py-1.5 text-sm rounded ${curPath == path ? 'bg-brand-tint text-brand-accent font-medium' : 'text-gray-700 hover:bg-gray-100 hover:text-gray-900'}" href="${ctx}${path}<c:if test="${not omitAgency and not empty param.a}">?a=${param.a}</c:if>"<c:if test="${not empty title}"> title="${title}"</c:if>><jsp:doBody/></a></li>

--- a/transitclockWebapp/src/main/webapp/WEB-INF/tags/secondarySidebarLink.tag
+++ b/transitclockWebapp/src/main/webapp/WEB-INF/tags/secondarySidebarLink.tag
@@ -7,7 +7,11 @@
      against the current servletPath to highlight the row, and is also the
      href. `omitAgency="true"` drops the ?a=... query string (e.g. for
      /reports/apiCalls/agenciesApiParams.jsp, which lists all agencies and
-     therefore takes no agency param). The body provides the link label. --%>
+     therefore takes no agency param). The body provides the link label.
+     Uses c:url + c:param so param.a is URL-encoded rather than pasted
+     straight into the href attribute. --%>
 <c:set var="curPath" value="${pageContext.request.servletPath}"/>
-<c:set var="ctx"     value="${pageContext.request.contextPath}"/>
-<li><a class="block px-2 py-1.5 text-sm rounded ${curPath == path ? 'bg-brand-tint text-brand-accent font-medium' : 'text-gray-700 hover:bg-gray-100 hover:text-gray-900'}" href="${ctx}${path}<c:if test="${not omitAgency and not empty param.a}">?a=${param.a}</c:if>"<c:if test="${not empty title}"> title="${title}"</c:if>><jsp:doBody/></a></li>
+<c:url var="href" value="${path}">
+  <c:if test="${not omitAgency and not empty param.a}"><c:param name="a" value="${param.a}"/></c:if>
+</c:url>
+<li><a class="block px-2 py-1.5 text-sm rounded ${curPath == path ? 'bg-brand-tint text-brand-accent font-medium' : 'text-gray-700 hover:bg-gray-100 hover:text-gray-900'}" href="${href}"<c:if test="${not empty title}"> title="${title}"</c:if>><jsp:doBody/></a></li>

--- a/transitclockWebapp/src/main/webapp/WEB-INF/tags/splitLayout.tag
+++ b/transitclockWebapp/src/main/webapp/WEB-INF/tags/splitLayout.tag
@@ -1,0 +1,23 @@
+<%@ tag pageEncoding="UTF-8" %>
+<%@ taglib prefix="t" tagdir="/WEB-INF/tags" %>
+<%@ attribute name="title"   required="false" %>
+<%@ attribute name="head"    fragment="true" required="false" %>
+<%@ attribute name="sidebar" fragment="true" required="true" %>
+<%-- Two-pane layout: a middle sidebar (passed in via the `sidebar` fragment)
+     and the main content (body). Used by index pages that present a list of
+     reports or API calls alongside an empty-state / detail pane.
+     bare="true" so the sidebar+content flex container can fill the main
+     pane itself; the default p-8 wrapper would double-pad. --%>
+<t:layout title="${title}" bare="true">
+  <jsp:attribute name="head">
+    <jsp:invoke fragment="head"/>
+  </jsp:attribute>
+  <jsp:body>
+    <div class="flex h-full">
+      <jsp:invoke fragment="sidebar"/>
+      <div class="flex-1 overflow-y-auto">
+        <jsp:doBody/>
+      </div>
+    </div>
+  </jsp:body>
+</t:layout>

--- a/transitclockWebapp/src/main/webapp/reports/apiCalls/agenciesApiParams.jsp
+++ b/transitclockWebapp/src/main/webapp/reports/apiCalls/agenciesApiParams.jsp
@@ -1,4 +1,4 @@
-<t:layout>
+<t:apiCallLayout>
   <jsp:attribute name="title"><fmt:message key="div.SpecifyParameters" /></jsp:attribute>
   <jsp:attribute name="head">
     <link href="../params/reportParams.css" rel="stylesheet"/>
@@ -26,4 +26,4 @@
 
 </div>
   </jsp:body>
-</t:layout>
+</t:apiCallLayout>

--- a/transitclockWebapp/src/main/webapp/reports/apiCalls/blocksApiParams.jsp
+++ b/transitclockWebapp/src/main/webapp/reports/apiCalls/blocksApiParams.jsp
@@ -1,4 +1,4 @@
-<t:layout>
+<t:apiCallLayout>
   <jsp:attribute name="title"><fmt:message key="div.SpecifyParameters" /></jsp:attribute>
   <jsp:attribute name="head">
     <!-- Load in Select2 files so can create fancy route selector -->
@@ -34,4 +34,4 @@
    <jsp:include page="../params/submitApiCall.jsp" />
 </div>
   </jsp:body>
-</t:layout>
+</t:apiCallLayout>

--- a/transitclockWebapp/src/main/webapp/reports/apiCalls/blocksTerseApiParams.jsp
+++ b/transitclockWebapp/src/main/webapp/reports/apiCalls/blocksTerseApiParams.jsp
@@ -1,4 +1,4 @@
-<t:layout>
+<t:apiCallLayout>
   <jsp:attribute name="title"><fmt:message key="div.SpecifyParameters" /></jsp:attribute>
   <jsp:attribute name="head">
     <!-- Load in Select2 files so can create fancy route selector -->
@@ -34,4 +34,4 @@
    <jsp:include page="../params/submitApiCall.jsp" />
 </div>
   </jsp:body>
-</t:layout>
+</t:apiCallLayout>

--- a/transitclockWebapp/src/main/webapp/reports/apiCalls/calendarsApiParams.jsp
+++ b/transitclockWebapp/src/main/webapp/reports/apiCalls/calendarsApiParams.jsp
@@ -1,4 +1,4 @@
-<t:layout>
+<t:apiCallLayout>
   <jsp:attribute name="title"><fmt:message key="div.SpecifyParameters" /></jsp:attribute>
   <jsp:attribute name="head">
     <link href="../params/reportParams.css" rel="stylesheet"/>
@@ -27,4 +27,4 @@
 
 </div>
   </jsp:body>
-</t:layout>
+</t:apiCallLayout>

--- a/transitclockWebapp/src/main/webapp/reports/apiCalls/calendarsCurrentApiParams.jsp
+++ b/transitclockWebapp/src/main/webapp/reports/apiCalls/calendarsCurrentApiParams.jsp
@@ -1,4 +1,4 @@
-<t:layout>
+<t:apiCallLayout>
   <jsp:attribute name="title"><fmt:message key="div.SpecifyParameters" /></jsp:attribute>
   <jsp:attribute name="head">
     <link href="../params/reportParams.css" rel="stylesheet"/>
@@ -27,4 +27,4 @@
 
 </div>
   </jsp:body>
-</t:layout>
+</t:apiCallLayout>

--- a/transitclockWebapp/src/main/webapp/reports/apiCalls/gtfsRealtimeTripUpdatesApiParams.jsp
+++ b/transitclockWebapp/src/main/webapp/reports/apiCalls/gtfsRealtimeTripUpdatesApiParams.jsp
@@ -1,4 +1,4 @@
-<t:layout>
+<t:apiCallLayout>
   <jsp:attribute name="title"><fmt:message key="div.SpecifyParameters" /></jsp:attribute>
   <jsp:attribute name="head">
     <!-- Load in Select2 files so can create fancy route selector -->
@@ -34,4 +34,4 @@
 
 </div>
   </jsp:body>
-</t:layout>
+</t:apiCallLayout>

--- a/transitclockWebapp/src/main/webapp/reports/apiCalls/gtfsRealtimeVehiclePositionsApiParams.jsp
+++ b/transitclockWebapp/src/main/webapp/reports/apiCalls/gtfsRealtimeVehiclePositionsApiParams.jsp
@@ -1,4 +1,4 @@
-<t:layout>
+<t:apiCallLayout>
   <jsp:attribute name="title"><fmt:message key="div.SpecifyParameters" /></jsp:attribute>
   <jsp:attribute name="head">
     <!-- Load in Select2 files so can create fancy route selector -->
@@ -34,4 +34,4 @@
 
 </div>
   </jsp:body>
-</t:layout>
+</t:apiCallLayout>

--- a/transitclockWebapp/src/main/webapp/reports/apiCalls/horizStopsScheduleApiParams.jsp
+++ b/transitclockWebapp/src/main/webapp/reports/apiCalls/horizStopsScheduleApiParams.jsp
@@ -1,4 +1,4 @@
-<t:layout>
+<t:apiCallLayout>
   <jsp:attribute name="title"><fmt:message key="div.SpecifyParameters" /></jsp:attribute>
   <jsp:attribute name="head">
     <!-- Load in Select2 files so can create fancy route selector -->
@@ -35,4 +35,4 @@
 
 </div>
   </jsp:body>
-</t:layout>
+</t:apiCallLayout>

--- a/transitclockWebapp/src/main/webapp/reports/apiCalls/index.jsp
+++ b/transitclockWebapp/src/main/webapp/reports/apiCalls/index.jsp
@@ -1,104 +1,15 @@
-<%@page import="org.transitclock.db.webstructs.WebAgency"%>
 <%
 String agencyId = request.getParameter("a");
 if (agencyId == null || agencyId.isEmpty()) {
     response.getWriter().write("You must specify agency in query string (e.g. ?a=mbta)");
     return;
 }
-pageContext.setAttribute("agencyId", agencyId);
-pageContext.setAttribute("agencyName", WebAgency.getCachedWebAgency(agencyId).getAgencyName());
 %>
-
-<t:layout>
+<t:splitLayout>
   <jsp:attribute name="title"><fmt:message key="div.apicalls" /></jsp:attribute>
+  <jsp:attribute name="sidebar"><t:apiCallsSidebar/></jsp:attribute>
   <jsp:body>
-    <div id="title"><fmt:message key="div.apicallsfor" />${agencyName}</div>
-    <div id="subtitle" style="margin-bottom: 20px;"><fmt:message key="div.notethisis" /></div>
-    <div id="subtitle"><fmt:message key="div.asac" /></div>
-    <ul class="list-disc list-outside pl-4">
-      <li><a href="routeApiParams.jsp?a=${agencyId}"
-        title="Summary data for all routes, listed in order. Useful for creating a UI selector for routes.">
-          <fmt:message key="div.rou" /></a></li>
-      <li><a href="routeDetailsApiParams.jsp?a=${agencyId}"
-        title="Detailed data for selected routes. Includes stop and path information needed to show route on map.">
-          <fmt:message key="div.roude" /></a></li>
-
-      <li><a href="vehiclesApiParams.jsp?a=${agencyId}"
-        title="Data for vehicles, including GPS info, for a route. Useful for showing location of vehicles on map.">
-          <fmt:message key="div.veh" /></a></li>
-      <li><a href="vehiclesDetailsApiParams.jsp?a=${agencyId}"
-        title="Detailed data for vehicles, including GPS info, for a route. Contains additional data such as schedule adherence and assignment information.">
-          <fmt:message key="div.vd" /></a></li>
-      <li><a href="vehicleConfigsApiParams.jsp?a=${agencyId}"
-        title="Configuration data for vehicles. A way of getting list of vehicles configured for agency.">
-          <fmt:message key="div.vc" /></a></li>
-
-      <li><a href="predsByRouteStopApiParams.jsp?a=${agencyId}"
-        title="Predictions for specified route and stop.">
-          <fmt:message key="div.pbrs" /></a></li>
-      <li><a href="predsByLocApiParams.jsp?a=${agencyId}"
-        title="Predictions for stops near specified latitude, longitude for the agency.">
-          <fmt:message key="div.pbl" /></a></li>
-      <li><a href="tripApiParams.jsp?a=${agencyId}"
-        title="Data for a single trip. Includes trip pattern and schedule info.">
-          <fmt:message key="div.dtrip" /></a></li>
-      <li><a href="tripWithTravelTimesApiParams.jsp?a=${agencyId}"
-        title="Data for a single trip. Includes trip pattern and schedule info as well as historic travel times used for generating predictions.">
-          <fmt:message key="div.twtt" /></a></li>
-      <li><a href="blocksTerseApiParams.jsp?a=${agencyId}"
-        title="Data for a block assignment. Shows each trip that makes up the block in a terse format, without trip pattern or schedule info.">
-          <fmt:message key="div.dblock" /></a></li>
-      <li><a href="blocksApiParams.jsp?a=${agencyId}"
-        title="Data for a block assignment. Shows each trip that makes up the block in a verbose format, including trip pattern and schedule info.">
-          <fmt:message key="div.bd" /></a></li>
-
-      <li><a href="serviceIdsApiParams.jsp?a=${agencyId}"
-        title="Data for all service IDs configured for agency.">
-          <fmt:message key="div.si" /></a></li>
-      <li><a href="serviceIdsCurrentApiParams.jsp?a=${agencyId}"
-        title="Data for service IDs that are currently active for agency.">
-          <fmt:message key="div.sic" /></a></li>
-
-      <li><a href="calendarsApiParams.jsp?a=${agencyId}"
-        title="Data for all calendars configured for agency.">
-          Calendars</a></li>
-      <li><a href="calendarsCurrentApiParams.jsp?a=${agencyId}"
-        title="Data for calendars that are currently active for agency.">
-          Calendars Current</a></li>
-
-      <li><a href="gtfsRealtimeTripUpdatesApiParams.jsp?a=${agencyId}"
-        title="GTFS-realtime Trip Updates includes prediction data for entire agency">
-          <fmt:message key="div.grtu" /></a></li>
-      <li><a href="gtfsRealtimeVehiclePositionsApiParams.jsp?a=${agencyId}"
-        title="GTFS-realtime Vehicle Positions for entire agency">
-          <fmt:message key="div.grvp" /></a></li>
-
-      <li><a href="siriVehicleMonitoringApiParams.jsp?a=${agencyId}"
-        title="SIRI Vehicle Monitoring for specified route or entire agency">
-          <fmt:message key="div.svm" /></a></li>
-      <li><a href="siriStopMonitoringApiParams.jsp?a=${agencyId}"
-        title="SIRI Stop Monitoring for specified route and stop">
-          <fmt:message key="div.ssm" /></a></li>
-
-      <li><a href="horizStopsScheduleApiParams.jsp?a=${agencyId}"
-        title="Schedule for route. For displaying schedule with stops listed in horizontal direction">
-          <fmt:message key="div.sfrsh" /></a></li>
-      <li><a href="vertStopsScheduleApiParams.jsp?a=${agencyId}"
-        title="Schedule for route. For displaying schedule with stops listed in vertical direction">
-          Schedule for Route, stops vertical</a></li>
-      <li><a href="resetVehicleApiParams.jsp?a=${agencyId}"
-        title="Reset specific vehicle">
-          <fmt:message key="div.sfrsv" /></a></li>
-    </ul>
-
-    <div id="subtitle">Not Agency Specific</div>
-    <ul class="list-disc list-outside pl-4">
-      <li><a href="agenciesApiParams.jsp"
-        title="List of all agencies available through the API">
-          <fmt:message key="div.agencies" /></a></li>
-      <li><a href="predsByLocForAllAgenciesApiParams.jsp?a=${agencyId}"
-        title="Predictions for stops near specified latitude, longitude. Will return predictions for all agencies that have nearby stops.">
-          <fmt:message key="div.pbl" /></a></li>
-    </ul>
+    <t:emptyState title="Choose an API call"
+                  message="Pick an API call from the list on the left to view its parameters."/>
   </jsp:body>
-</t:layout>
+</t:splitLayout>

--- a/transitclockWebapp/src/main/webapp/reports/apiCalls/predsByLocApiParams.jsp
+++ b/transitclockWebapp/src/main/webapp/reports/apiCalls/predsByLocApiParams.jsp
@@ -1,4 +1,4 @@
-<t:layout>
+<t:apiCallLayout>
   <jsp:attribute name="title"><fmt:message key="div.SpecifyParameters" /></jsp:attribute>
   <jsp:attribute name="head">
     <!-- Load in Select2 files so can create fancy route selector -->
@@ -56,4 +56,4 @@
    <jsp:include page="../params/submitApiCall.jsp" />
 </div>
   </jsp:body>
-</t:layout>
+</t:apiCallLayout>

--- a/transitclockWebapp/src/main/webapp/reports/apiCalls/predsByLocForAllAgenciesApiParams.jsp
+++ b/transitclockWebapp/src/main/webapp/reports/apiCalls/predsByLocForAllAgenciesApiParams.jsp
@@ -1,4 +1,4 @@
-<t:layout>
+<t:apiCallLayout>
   <jsp:attribute name="title"><fmt:message key="div.SpecifyParameters" /></jsp:attribute>
   <jsp:attribute name="head">
     <!-- Load in Select2 files so can create fancy route selector -->
@@ -57,4 +57,4 @@
 
 </div>
   </jsp:body>
-</t:layout>
+</t:apiCallLayout>

--- a/transitclockWebapp/src/main/webapp/reports/apiCalls/predsByRouteStopApiParams.jsp
+++ b/transitclockWebapp/src/main/webapp/reports/apiCalls/predsByRouteStopApiParams.jsp
@@ -1,4 +1,4 @@
-<t:layout>
+<t:apiCallLayout>
   <jsp:attribute name="title"><fmt:message key="div.SpecifyParameters" /></jsp:attribute>
   <jsp:attribute name="head">
     <!-- Load in Select2 files so can create fancy route selector -->
@@ -48,4 +48,4 @@
    <jsp:include page="../params/submitApiCall.jsp" />
 </div>
   </jsp:body>
-</t:layout>
+</t:apiCallLayout>

--- a/transitclockWebapp/src/main/webapp/reports/apiCalls/resetVehicleApiParams.jsp
+++ b/transitclockWebapp/src/main/webapp/reports/apiCalls/resetVehicleApiParams.jsp
@@ -1,4 +1,4 @@
-<t:layout>
+<t:apiCallLayout>
   <jsp:attribute name="title"><fmt:message key="div.SpecifyParameters" /></jsp:attribute>
   <jsp:attribute name="head">
     <!-- Load in Select2 files so can create fancy route selector -->
@@ -34,4 +34,4 @@
    <jsp:include page="../params/submitApiCall.jsp" />
 </div>
   </jsp:body>
-</t:layout>
+</t:apiCallLayout>

--- a/transitclockWebapp/src/main/webapp/reports/apiCalls/routeApiParams.jsp
+++ b/transitclockWebapp/src/main/webapp/reports/apiCalls/routeApiParams.jsp
@@ -1,4 +1,4 @@
-<t:layout>
+<t:apiCallLayout>
   <jsp:attribute name="title"><fmt:message key="div.SpecifyParameters" /></jsp:attribute>
   <jsp:attribute name="head">
     <!-- Load in Select2 files so can create fancy route selector -->
@@ -31,4 +31,4 @@
    <jsp:include page="../params/submitApiCall.jsp" />
 </div>
   </jsp:body>
-</t:layout>
+</t:apiCallLayout>

--- a/transitclockWebapp/src/main/webapp/reports/apiCalls/routeDetailsApiParams.jsp
+++ b/transitclockWebapp/src/main/webapp/reports/apiCalls/routeDetailsApiParams.jsp
@@ -1,4 +1,4 @@
-<t:layout>
+<t:apiCallLayout>
   <jsp:attribute name="title"><fmt:message key="div.SpecifyParameters" /></jsp:attribute>
   <jsp:attribute name="head">
     <!-- Load in Select2 files so can create fancy route selector -->
@@ -40,4 +40,4 @@
    <jsp:include page="../params/submitApiCall.jsp" />
 </div>
   </jsp:body>
-</t:layout>
+</t:apiCallLayout>

--- a/transitclockWebapp/src/main/webapp/reports/apiCalls/serviceIdsApiParams.jsp
+++ b/transitclockWebapp/src/main/webapp/reports/apiCalls/serviceIdsApiParams.jsp
@@ -1,4 +1,4 @@
-<t:layout>
+<t:apiCallLayout>
   <jsp:attribute name="title"><fmt:message key="div.SpecifyParameters" /></jsp:attribute>
   <jsp:attribute name="head">
     <link href="../params/reportParams.css" rel="stylesheet"/>
@@ -27,4 +27,4 @@
 
 </div>
   </jsp:body>
-</t:layout>
+</t:apiCallLayout>

--- a/transitclockWebapp/src/main/webapp/reports/apiCalls/serviceIdsCurrentApiParams.jsp
+++ b/transitclockWebapp/src/main/webapp/reports/apiCalls/serviceIdsCurrentApiParams.jsp
@@ -1,4 +1,4 @@
-<t:layout>
+<t:apiCallLayout>
   <jsp:attribute name="title"><fmt:message key="div.SpecifyParameters" /></jsp:attribute>
   <jsp:attribute name="head">
     <link href="../params/reportParams.css" rel="stylesheet"/>
@@ -27,4 +27,4 @@
 
 </div>
   </jsp:body>
-</t:layout>
+</t:apiCallLayout>

--- a/transitclockWebapp/src/main/webapp/reports/apiCalls/siriStopMonitoringApiParams.jsp
+++ b/transitclockWebapp/src/main/webapp/reports/apiCalls/siriStopMonitoringApiParams.jsp
@@ -1,4 +1,4 @@
-<t:layout>
+<t:apiCallLayout>
   <jsp:attribute name="title"><fmt:message key="div.SpecifyParameters" /></jsp:attribute>
   <jsp:attribute name="head">
     <!-- Load in Select2 files so can create fancy route selector -->
@@ -49,4 +49,4 @@
    <jsp:include page="../params/submitApiCall.jsp" />
 </div>
   </jsp:body>
-</t:layout>
+</t:apiCallLayout>

--- a/transitclockWebapp/src/main/webapp/reports/apiCalls/siriVehicleMonitoringApiParams.jsp
+++ b/transitclockWebapp/src/main/webapp/reports/apiCalls/siriVehicleMonitoringApiParams.jsp
@@ -1,4 +1,4 @@
-<t:layout>
+<t:apiCallLayout>
   <jsp:attribute name="title"><fmt:message key="div.SpecifyParameters" /></jsp:attribute>
   <jsp:attribute name="head">
     <!-- Load in Select2 files so can create fancy route selector -->
@@ -34,4 +34,4 @@
    <jsp:include page="../params/submitApiCall.jsp" />
 </div>
   </jsp:body>
-</t:layout>
+</t:apiCallLayout>

--- a/transitclockWebapp/src/main/webapp/reports/apiCalls/tripApiParams.jsp
+++ b/transitclockWebapp/src/main/webapp/reports/apiCalls/tripApiParams.jsp
@@ -1,4 +1,4 @@
-<t:layout>
+<t:apiCallLayout>
   <jsp:attribute name="title"><fmt:message key="div.SpecifyParameters" /></jsp:attribute>
   <jsp:attribute name="head">
     <link href="../params/reportParams.css" rel="stylesheet"/>
@@ -35,4 +35,4 @@
    <jsp:include page="../params/submitApiCall.jsp" />
 </div>
   </jsp:body>
-</t:layout>
+</t:apiCallLayout>

--- a/transitclockWebapp/src/main/webapp/reports/apiCalls/tripWithTravelTimesApiParams.jsp
+++ b/transitclockWebapp/src/main/webapp/reports/apiCalls/tripWithTravelTimesApiParams.jsp
@@ -1,4 +1,4 @@
-<t:layout>
+<t:apiCallLayout>
   <jsp:attribute name="title"><fmt:message key="div.SpecifyParameters" /></jsp:attribute>
   <jsp:attribute name="head">
     <link href="../params/reportParams.css" rel="stylesheet"/>
@@ -35,4 +35,4 @@
    <jsp:include page="../params/submitApiCall.jsp" />
 </div>
   </jsp:body>
-</t:layout>
+</t:apiCallLayout>

--- a/transitclockWebapp/src/main/webapp/reports/apiCalls/vehicleConfigsApiParams.jsp
+++ b/transitclockWebapp/src/main/webapp/reports/apiCalls/vehicleConfigsApiParams.jsp
@@ -1,4 +1,4 @@
-<t:layout>
+<t:apiCallLayout>
   <jsp:attribute name="title"><fmt:message key="div.SpecifyParameters" /></jsp:attribute>
   <jsp:attribute name="head">
     <link href="../params/reportParams.css" rel="stylesheet"/>
@@ -27,4 +27,4 @@
 
 </div>
   </jsp:body>
-</t:layout>
+</t:apiCallLayout>

--- a/transitclockWebapp/src/main/webapp/reports/apiCalls/vehiclesApiParams.jsp
+++ b/transitclockWebapp/src/main/webapp/reports/apiCalls/vehiclesApiParams.jsp
@@ -1,4 +1,4 @@
-<t:layout>
+<t:apiCallLayout>
   <jsp:attribute name="title"><fmt:message key="div.SpecifyParameters" /></jsp:attribute>
   <jsp:attribute name="head">
     <!-- Load in Select2 files so can create fancy route selector -->
@@ -34,4 +34,4 @@
    <jsp:include page="../params/submitApiCall.jsp" />
 </div>
   </jsp:body>
-</t:layout>
+</t:apiCallLayout>

--- a/transitclockWebapp/src/main/webapp/reports/apiCalls/vehiclesDetailsApiParams.jsp
+++ b/transitclockWebapp/src/main/webapp/reports/apiCalls/vehiclesDetailsApiParams.jsp
@@ -1,4 +1,4 @@
-<t:layout>
+<t:apiCallLayout>
   <jsp:attribute name="title"><fmt:message key="div.SpecifyParameters" /></jsp:attribute>
   <jsp:attribute name="head">
     <!-- Load in Select2 files so can create fancy route selector -->
@@ -34,4 +34,4 @@
    <jsp:include page="../params/submitApiCall.jsp" />
 </div>
   </jsp:body>
-</t:layout>
+</t:apiCallLayout>

--- a/transitclockWebapp/src/main/webapp/reports/apiCalls/vertStopsScheduleApiParams.jsp
+++ b/transitclockWebapp/src/main/webapp/reports/apiCalls/vertStopsScheduleApiParams.jsp
@@ -1,4 +1,4 @@
-<t:layout>
+<t:apiCallLayout>
   <jsp:attribute name="title">
     <fmt:message key="div.SpecifyParameters" />
   </jsp:attribute>
@@ -34,4 +34,4 @@
     <%-- Create submit button --%>
     <jsp:include page="../params/submitApiCall.jsp" />
   </jsp:body>
-</t:layout>
+</t:apiCallLayout>


### PR DESCRIPTION
## Summary
- Adopts the same middle-column sidebar pattern as `reports/index.jsp` for `reports/apiCalls/index.jsp`, extracted into reusable JSP tags so both pages share styling.
- New tags: `splitLayout.tag` (generic 2-column wrapper), `secondarySidebar.tag` (middle-column shell), `secondarySidebarLink.tag` (active-state link with `?a=...` handling), `apiCallsSidebar.tag` (sectioned API calls list). `reportsLayout.tag` and `reportsSidebar.tag` are refactored onto these primitives.
- Fixes a visual mismatch: the middle-column active-link highlight was `bg-indigo-50 text-indigo-700` (purple) and didn't match the brand-green of the main left sidebar. Now uses `bg-brand-tint text-brand-accent`.

## Drive-by fixes
- The Reset Vehicle row was rendering `<fmt:message key="div.sfrsv"/>` which resolves to "Schedule for Route, stops vertical" — clearly a copy-paste bug. Switched to `div.rv` ("Reset vehicle"). The vertical-schedule row, which had a hardcoded English string instead of a key, now uses `div.sfrsv` correctly.

## Test plan
- [x] `mvn -pl transitclockWebapp -am package -DskipTests` builds clean
- [x] `/web/reports/apiCalls/index.jsp?a=1` renders the new 3-column layout with empty-state pane
- [x] `/web/reports/index.jsp?a=1` still renders correctly (refactored layout chain)
- [x] `/web/reports/routePerformanceTable.jsp?a=1` shows the new brand-green active-link highlight in the middle column
- [x] `/web/reports/apiCalls/routeApiParams.jsp?a=1` (a sub-page using `t:layout`, not `t:splitLayout`) still renders without regression
- [x] Verified URL composition for `secondarySidebarLink` `omitAgency`: `agenciesApiParams.jsp` has no `?a=`, `predsByLocForAllAgenciesApiParams.jsp` keeps it

## Follow-ups (not blocking)
- `apiCallsSidebar.tag` has hardcoded English section headings ("GTFS-realtime", "SIRI", etc.) and link labels ("Calendars", "Calendars Current") because no `text.properties` keys exist for them. Adding new keys would require coordinating a Polish translation update.
- `div.pbl` ("Predictions by Location") is reused as the label for both `predsByLocApiParams` and `predsByLocForAllAgenciesApiParams`. A new key like `div.pblall = Predictions by Location (all agencies)` would disambiguate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated, sectioned "API Calls" secondary sidebar for navigating API endpoints (GTFS‑realtime, SIRI, schedules, etc.).
  * Introduced a reusable split-layout for two‑pane pages so the sidebar stays visible alongside content.
  * Updated all API-call pages to use the new layout, showing a consistent sidebar and an empty-state prompt until an API is selected.
  * Consistent link presentation and navigation across reports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->